### PR TITLE
Add documentation for crates.io publishing

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -5,10 +5,25 @@ authors = ["Marcin Spoczynski <marcin@spoczynski.com>"]
 edition = "2021"
 rust-version = "1.75"
 description = "Core functionality for Atlas ML provenance system"
-license = "MIT OR Apache-2.0"
+documentation = "https://docs.rs/atlas-core"
+homepage = "https://github.com/IntelLabs/atlas-core"
 repository = "https://github.com/IntelLabs/atlas-core"
+readme = "README.md"
+license = "Apache-2.0"
 keywords = ["c2pa", "ml", "provenance", "integrity", "hash"]
 categories = ["cryptography", "data-structures"]
+exclude = [
+    ".github/*",
+    "tests/*",
+    "benches/*",
+    ".gitignore",
+    "test.sh",
+]
+
+# Metadata for docs.rs
+[package.metadata.docs.rs]
+all-features = true
+rustdoc-args = ["--cfg", "docsrs"]
 
 [dependencies]
 # Core dependencies (always included)
@@ -36,7 +51,7 @@ default = ["hash", "c2pa"]
 hash = ["dep:sha2", "dep:hex", "dep:subtle"]
 c2pa = ["dep:uuid", "dep:time"]
 storage = ["dep:async-trait"]
-validation = ["c2pa", "hash"]  # Validation needs both for full functionality
+validation = ["c2pa", "hash", "dep:uuid"]
 file-utils = []  # No additional deps needed
 
 # Async support for storage
@@ -55,6 +70,18 @@ name = "hash_benchmark"
 harness = false
 required-features = ["hash"]
 
+[[example]]
+name = "basic_hashing"
+required-features = ["hash"]
+
+[[example]]
+name = "c2pa_manifest"
+required-features = ["c2pa"]
+
+[[example]]
+name = "full_example"
+required-features = ["all"]
+
 [profile.release]
 opt-level = 3
 lto = true
@@ -63,3 +90,11 @@ codegen-units = 1
 [profile.dev]
 opt-level = 0
 debug = true
+
+[profile.bench]
+inherits = "release"
+
+[package.metadata.links]
+"CI/CD" = "https://github.com/IntelLabs/atlas-core/actions"
+"Bug Reports" = "https://github.com/IntelLabs/atlas-core/issues"
+"C2PA Specification" = "https://c2pa.org/specifications/"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,13 +1,13 @@
 [package]
-name = "atlas-core"
+name = "atlas-common"
 version = "0.1.0"
-authors = ["Marcin Spoczynski <marcin@spoczynski.com>"]
+authors = ["Marcin Spoczynski <marcin@spoczynski.com>", "Marcela Melara <marcela.melara@intel.com"]
 edition = "2021"
 rust-version = "1.75"
-description = "Core functionality for Atlas ML provenance system"
-documentation = "https://docs.rs/atlas-core"
-homepage = "https://github.com/IntelLabs/atlas-core"
-repository = "https://github.com/IntelLabs/atlas-core"
+description = "Common functionality for Atlas ML provenance system"
+documentation = "https://docs.rs/atlas-common"
+homepage = "https://github.com/IntelLabs/atlas-common"
+repository = "https://github.com/IntelLabs/atlas-common"
 readme = "README.md"
 license = "Apache-2.0"
 keywords = ["c2pa", "ml", "provenance", "integrity", "hash"]
@@ -95,6 +95,6 @@ debug = true
 inherits = "release"
 
 [package.metadata.links]
-"CI/CD" = "https://github.com/IntelLabs/atlas-core/actions"
-"Bug Reports" = "https://github.com/IntelLabs/atlas-core/issues"
+"CI/CD" = "https://github.com/IntelLabs/atlas-common/actions"
+"Bug Reports" = "https://github.com/IntelLabs/atlas-common/issues"
 "C2PA Specification" = "https://c2pa.org/specifications/"

--- a/README.md
+++ b/README.md
@@ -176,7 +176,7 @@ Run examples with:
 ```bash
 cargo run --example basic_hashing --features hash
 cargo run --example c2pa_manifest --features c2pa
-cargo run --example full_example --features full
+cargo run --example full_example --features all
 ```
 
 ## Benchmarks

--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@
 
 ⚠️ **Disclaimer**: This project is currently in active development. The code is **not stable** and **not intended for use in production environments**. Interfaces, features, and behaviors are subject to change without notice.
 
-Core functionality for machine learning provenance tracking with C2PA (Coalition for Content Provenance and Authenticity) support.
+Core functionality for machine learning provenance tracking with [C2PA](https://spec.c2pa.org/specifications/specifications/2.2/index.html) (Coalition for Content Provenance and Authenticity) support.
 
 Atlas Common provides essential building blocks for creating content authenticity systems that track the provenance of machine learning models, datasets, and related assets throughout their lifecycle.
 

--- a/README.md
+++ b/README.md
@@ -1,15 +1,15 @@
-[![OpenSSF Scorecard](https://api.scorecard.dev/projects/github.com/IntelLabs/atlas-core/badge)](https://scorecard.dev/viewer/?uri=github.com/IntelLabs/atlas-core)
-![GitHub License](https://img.shields.io/github/license/IntelLabs/atlas-core)
-[![Crates.io](https://img.shields.io/crates/v/atlas-core.svg)](https://crates.io/crates/atlas-core)
-[![Documentation](https://docs.rs/atlas-core/badge.svg)](https://docs.rs/atlas-core)
+[![OpenSSF Scorecard](https://api.scorecard.dev/projects/github.com/IntelLabs/atlas-common/badge)](https://scorecard.dev/viewer/?uri=github.com/IntelLabs/atlas-common)
+![GitHub License](https://img.shields.io/github/license/IntelLabs/atlas-common)
+[![Crates.io](https://img.shields.io/crates/v/atlas-common.svg)](https://crates.io/crates/atlas-common)
+[![Documentation](https://docs.rs/atlas-common/badge.svg)](https://docs.rs/atlas-common)
 
-# Atlas Core
+# Atlas Common
 
 ⚠️ **Disclaimer**: This project is currently in active development. The code is **not stable** and **not intended for use in production environments**. Interfaces, features, and behaviors are subject to change without notice.
 
 Core functionality for machine learning provenance tracking with C2PA (Coalition for Content Provenance and Authenticity) support.
 
-Atlas Core provides essential building blocks for creating content authenticity systems that track the provenance of machine learning models, datasets, and related assets throughout their lifecycle.
+Atlas Common provides essential building blocks for creating content authenticity systems that track the provenance of machine learning models, datasets, and related assets throughout their lifecycle.
 
 ## Features
 
@@ -26,7 +26,7 @@ Add this to your `Cargo.toml`:
 
 ```toml
 [dependencies]
-atlas-core = "0.1.0"
+atlas-common = "0.1.0"
 ```
 
 ### Feature Flags
@@ -43,7 +43,7 @@ To use specific features:
 
 ```toml
 [dependencies]
-atlas-core = { version = "0.1.0", features = ["all"] }
+atlas-common = { version = "0.1.0", features = ["all"] }
 ```
 
 ## Quick Start
@@ -51,7 +51,7 @@ atlas-core = { version = "0.1.0", features = ["all"] }
 ### Hashing
 
 ```rust
-use atlas_core::hash::{calculate_hash, verify_hash, HashAlgorithm};
+use atlas_common::hash::{calculate_hash, verify_hash, HashAlgorithm};
 
 // Calculate hash with default algorithm (SHA-384)
 let data = b"important data";
@@ -67,7 +67,7 @@ let sha256_hash = calculate_hash_with_algorithm(data, &HashAlgorithm::Sha256);
 ### C2PA Manifests
 
 ```rust
-use atlas_core::c2pa::{ManifestId, ManifestMetadata, ManifestType, DateTimeWrapper};
+use atlas_common::c2pa::{ManifestId, ManifestMetadata, ManifestType, DateTimeWrapper};
 
 // Create a manifest ID
 let manifest_id = ManifestId::new();
@@ -88,7 +88,7 @@ let metadata = ManifestMetadata {
 ### Asset Type Detection
 
 ```rust
-use atlas_core::c2pa::{determine_asset_type, AssetKind};
+use atlas_common::c2pa::{determine_asset_type, AssetKind};
 use std::path::Path;
 
 let model_path = Path::new("model.onnx");
@@ -99,7 +99,7 @@ let asset_type = determine_asset_type(model_path, AssetKind::Model)?;
 ### Secure File Operations
 
 ```rust
-use atlas_core::file::{safe_create_file, safe_open_file};
+use atlas_common::file::{safe_create_file, safe_open_file};
 use std::io::{Read, Write};
 
 // Safely create a file (blocks symlink attacks)
@@ -115,7 +115,7 @@ file.read_to_string(&mut contents)?;
 ### Validation
 
 ```rust
-use atlas_core::validation::{validate_manifest_id, ensure_c2pa_urn};
+use atlas_common::validation::{validate_manifest_id, ensure_c2pa_urn};
 
 // Validate a manifest ID
 validate_manifest_id("urn:c2pa:123e4567-e89b-12d3-a456-426614174000")?;
@@ -130,7 +130,7 @@ assert!(urn.starts_with("urn:c2pa:"));
 ### Incremental Hashing
 
 ```rust
-use atlas_core::hash::{HashBuilder, HashAlgorithm};
+use atlas_common::hash::{HashBuilder, HashAlgorithm};
 
 let mut builder = HashBuilder::new(HashAlgorithm::Sha256);
 builder.update(b"chunk1");
@@ -142,7 +142,7 @@ let hash = builder.finalize();
 ### Hash Trait
 
 ```rust
-use atlas_core::hash::{Hasher, HashAlgorithm};
+use atlas_common::hash::{Hasher, HashAlgorithm};
 
 let text = "Hello, World!";
 let hash = text.hash(HashAlgorithm::Sha512);
@@ -154,7 +154,7 @@ let hash2 = bytes.hash_default(); // Uses SHA-384
 ### Storage Backend
 
 ```rust
-use atlas_core::storage::{StorageConfig, StorageType};
+use atlas_common::storage::{StorageConfig, StorageType};
 
 let config = StorageConfig {
     storage_type: StorageType::S3,

--- a/README.md
+++ b/README.md
@@ -1,79 +1,115 @@
-
-![GitHub License](https://img.shields.io/github/license/IntelLabs/il-opensource-template)
-[![OpenSSF Scorecard](https://api.scorecard.dev/projects/github.com/IntelLabs/il-opensource-template/badge)](https://scorecard.dev/viewer/?uri=github.com/IntelLabs/il-opensource-template)
-<!-- UNCOMMENT AS NEEDED
-[![Unit Tests](https://github.com/IntelLabs/ConvAssist/actions/workflows/run_unittests.yaml/badge.svg?branch=covassist-cleanup)](https://github.com/IntelLabs/ConvAssist/actions/workflows/run_unittests.yaml)
-[![pytorch](https://img.shields.io/badge/PyTorch-v2.4.1-green?logo=pytorch)](https://pytorch.org/get-started/locally/)
-![python-support](https://img.shields.io/badge/Python-3.12-3?logo=python)
--->
+[![OpenSSF Scorecard](https://api.scorecard.dev/projects/github.com/IntelLabs/atlas-core/badge)](https://scorecard.dev/viewer/?uri=github.com/IntelLabs/atlas-core)
+![GitHub License](https://img.shields.io/github/license/IntelLabs/atlas-core)
+[![Crates.io](https://img.shields.io/crates/v/atlas-core.svg)](https://crates.io/crates/atlas-core)
+[![Documentation](https://docs.rs/atlas-core/badge.svg)](https://docs.rs/atlas-core)
 
 # Atlas Core
 
-Core functionality library for the Atlas ML provenance system, providing cryptographic hashing, C2PA manifest management, storage abstractions, and validation utilities.
+⚠️ **Disclaimer**: This project is currently in active development. The code is **not stable** and **not intended for use in production environments**. Interfaces, features, and behaviors are subject to change without notice.
+
+Core functionality for machine learning provenance tracking with C2PA (Coalition for Content Provenance and Authenticity) support.
+
+Atlas Core provides essential building blocks for creating content authenticity systems that track the provenance of machine learning models, datasets, and related assets throughout their lifecycle.
 
 ## Features
 
-Atlas Core is designed with modularity in mind. You can use only the features you need:
-
-- **`hash`** (default): Cryptographic hash functions supporting SHA-256, SHA-384, and SHA-512
-- **`c2pa`** (default): C2PA manifest and asset type definitions for ML artifacts
-- **`storage`**: Abstract storage backend interface for manifest persistence
-- **`validation`**: Validation utilities for manifests, URNs, and hashes
-- **`file-utils`**: Secure file operations with symlink and hard link protection
-- **`async`**: Async support for storage operations
-- **`all`**: Enable all features
+- 🔐 **Cryptographic Hashing**: SHA-256/384/512 with constant-time comparison
+- 📋 **C2PA Metadata**: Types and utilities for C2PA manifest management  
+- 💾 **Storage Abstractions**: Backend-agnostic storage interfaces
+- ✅ **Validation**: Validation for manifests, URNs, and hashes
+- 🛡️ **Secure File Operations**: Protection against symlink and hardlink attacks
+- ⚡ **Async Support**: Optional async/await for storage operations
 
 ## Installation
 
-Add to your `Cargo.toml`:
+Add this to your `Cargo.toml`:
 
 ```toml
-# Default features (hash + c2pa)
-atlas-core = "0.1"
-
-# Only hashing functionality
-atlas-core = { version = "0.1", default-features = false, features = ["hash"] }
-
-# Only C2PA types
-atlas-core = { version = "0.1", default-features = false, features = ["c2pa"] }
-
-# Everything
-atlas-core = { version = "0.1", features = ["full"] }
+[dependencies]
+atlas-core = "0.1.0"
 ```
 
-## Usage Examples
+### Feature Flags
+
+- `hash` (default): Cryptographic hash functions
+- `c2pa` (default): C2PA manifest and asset types
+- `storage`: Storage backend abstractions
+- `validation`: Validation utilities
+- `file-utils`: Secure file operation utilities
+- `async`: Async support for storage operations
+- `full`: Enable all features
+
+To use specific features:
+
+```toml
+[dependencies]
+atlas-core = { version = "0.1.0", features = ["all"] }
+```
+
+## Quick Start
 
 ### Hashing
 
 ```rust
-use atlas_core::hash::{calculate_hash, HashAlgorithm, Hasher};
+use atlas_core::hash::{calculate_hash, verify_hash, HashAlgorithm};
 
-// Basic hashing with default algorithm (SHA-384)
-let data = b"Model weights v1.0";
+// Calculate hash with default algorithm (SHA-384)
+let data = b"important data";
 let hash = calculate_hash(data);
 
-// Hash with specific algorithm
-let sha256_hash = data.hash(HashAlgorithm::Sha256);
-
 // Verify hash
-assert!(atlas_core::hash::verify_hash(data, &hash));
+assert!(verify_hash(data, &hash));
+
+// Use specific algorithm
+let sha256_hash = calculate_hash_with_algorithm(data, &HashAlgorithm::Sha256);
 ```
 
 ### C2PA Manifests
 
 ```rust
-use atlas_core::c2pa::{ManifestId, ManifestType, AssetType, AssetKind};
-use atlas_core::c2pa::determine_asset_type;
-use std::path::Path;
+use atlas_core::c2pa::{ManifestId, ManifestMetadata, ManifestType, DateTimeWrapper};
 
-// Create manifest ID
+// Create a manifest ID
 let manifest_id = ManifestId::new();
 println!("URN: {}", manifest_id.as_urn());
 
-// Detect asset type
+// Create manifest metadata
+let metadata = ManifestMetadata {
+    id: manifest_id.as_urn().to_string(),
+    name: "GPT-2 Fine-tuned Model".to_string(),
+    manifest_type: ManifestType::Model,
+    created_at: DateTimeWrapper::now_utc().to_rfc3339(),
+    hash: Some(calculate_hash(b"model data")),
+    size: Some(1024 * 1024 * 50), // 50 MB
+    version: Some("1.0.0".to_string()),
+};
+```
+
+### Asset Type Detection
+
+```rust
+use atlas_core::c2pa::{determine_asset_type, AssetKind};
+use std::path::Path;
+
 let model_path = Path::new("model.onnx");
 let asset_type = determine_asset_type(model_path, AssetKind::Model)?;
-assert_eq!(asset_type, AssetType::ModelOnnx);
+// Returns AssetType::ModelOnnx
+```
+
+### Secure File Operations
+
+```rust
+use atlas_core::file::{safe_create_file, safe_open_file};
+use std::io::{Read, Write};
+
+// Safely create a file (blocks symlink attacks)
+let mut file = safe_create_file(Path::new("output.txt"), false)?;
+file.write_all(b"secure data")?;
+
+// Safely read a file
+let mut file = safe_open_file(Path::new("input.txt"), false)?;
+let mut contents = String::new();
+file.read_to_string(&mut contents)?;
 ```
 
 ### Validation
@@ -81,110 +117,109 @@ assert_eq!(asset_type, AssetType::ModelOnnx);
 ```rust
 use atlas_core::validation::{validate_manifest_id, ensure_c2pa_urn};
 
-// Validate manifest ID
-let urn = "urn:c2pa:123e4567-e89b-12d3-a456-426614174000";
-validate_manifest_id(urn)?;
+// Validate a manifest ID
+validate_manifest_id("urn:c2pa:123e4567-e89b-12d3-a456-426614174000")?;
 
 // Ensure proper URN format
-let formatted = ensure_c2pa_urn("my-model-123");
-// Returns: urn:c2pa:<generated-uuid>
+let urn = ensure_c2pa_urn("my-custom-id");
+assert!(urn.starts_with("urn:c2pa:"));
 ```
 
-### Secure File Operations
+## Advanced Usage
+
+### Incremental Hashing
 
 ```rust
-use atlas_core::file::{safe_create_file, safe_open_file};
-use std::io::Write;
+use atlas_core::hash::{HashBuilder, HashAlgorithm};
 
-// Safely create a file (prevents symlink attacks)
-let mut file = safe_create_file(path, false)?;
-file.write_all(b"Secure content")?;
-
-// Safely read a file
-let mut file = safe_open_file(path, false)?;
+let mut builder = HashBuilder::new(HashAlgorithm::Sha256);
+builder.update(b"chunk1");
+builder.update(b"chunk2");
+builder.update(b"chunk3");
+let hash = builder.finalize();
 ```
 
-### Storage Backends
+### Hash Trait
 
 ```rust
-use atlas_core::storage::{StorageBackend, StorageConfig, StorageType};
+use atlas_core::hash::{Hasher, HashAlgorithm};
+
+let text = "Hello, World!";
+let hash = text.hash(HashAlgorithm::Sha512);
+
+let bytes = b"raw bytes";
+let hash2 = bytes.hash_default(); // Uses SHA-384
+```
+
+### Storage Backend
+
+```rust
+use atlas_core::storage::{StorageConfig, StorageType};
 
 let config = StorageConfig {
-    storage_type: StorageType::Filesystem,
-    path: Some("/var/atlas/manifests".to_string()),
+    storage_type: StorageType::S3,
+    url: Some("s3://my-bucket/manifests".to_string()),
     ..Default::default()
 };
-
-// Implement StorageBackend trait for your storage system
 ```
 
-## Module Organization
+## Examples
 
-```
-src/
-├── lib.rs           # Main entry point with feature gates
-├── error.rs         # Common error types (always available)
-├── hash/            # Cryptographic hashing (feature: hash)
-├── c2pa/            # C2PA types and utilities (feature: c2pa)
-├── storage/         # Storage abstractions (feature: storage)
-├── validation/      # Validation utilities (feature: validation)
-└── file/            # Secure file operations (feature: file-utils)
-```
+The repository includes several examples demonstrating various features:
 
-## Building
+- `basic_hashing` - Hash operations and verification
+- `c2pa_manifest` - Working with C2PA manifests
+- `full_example` - Complete demonstration of all features
+
+Run examples with:
 
 ```bash
-# Build with default features (hash + c2pa)
-cargo build
-
-# Build with all features
-cargo build --all-features
-
-# Build with specific features
-cargo build --features storage,validation
-```
-
-## Running Examples
-
-Examples require specific features to be enabled:
-
-```bash
-# Simple example with default features
-cargo run --example simple
-
-# Basic hashing example (requires 'hash' feature)
-cargo run --example basic_hashing
-
-# C2PA manifest example (requires 'c2pa' feature)  
-cargo run --example c2pa_manifest
-
-# Full functionality example (requires 'full' feature)
+cargo run --example basic_hashing --features hash
+cargo run --example c2pa_manifest --features c2pa
 cargo run --example full_example --features full
 ```
 
-## Testing
+## Benchmarks
+
+Performance benchmarks are available for hash operations:
 
 ```bash
-# Run all tests
-cargo test --all-features
-
-# Test specific feature
-cargo test --features hash
-cargo test --features c2pa
-
-# Run with coverage
-cargo tarpaulin --all-features
+cargo bench --features hash
 ```
 
-## Security Features
+## Security Considerations
 
-- **Symlink Protection**: File operations validate symlinks to prevent directory traversal
-- **Hard Link Detection**: Detects files with multiple hard links on Unix systems
-- **Constant-Time Comparison**: Hash verification uses constant-time comparison to prevent timing attacks
-- **Input Validation**: Comprehensive validation for all C2PA URNs and manifest IDs
+- **Constant-time comparison**: Hash verification uses constant-time comparison to prevent timing attacks
+- **Path validation**: File operations validate paths to prevent symlink and hardlink attacks
+- **Input validation**: All inputs are validated to prevent injection attacks
+- **Secure defaults**: SHA-384 is the default hash algorithm for optimal security/performance balance
+
+## Supported Formats
+
+### Model Formats
+- TensorFlow: `.pb`, `.savedmodel`, `.tf`
+- PyTorch: `.pt`, `.pth`, `.pytorch`
+- ONNX: `.onnx`
+- OpenVINO: `.bin`, `.xml`
+- Keras/HDF5: `.h5`, `.keras`, `.hdf5`
+
+### Dataset Formats
+- Tabular: `.csv`, `.tsv`, `.txt`
+- JSON: `.json`, `.jsonl`
+- Big Data: `.parquet`, `.orc`, `.avro`
+- TensorFlow: `.tfrecord`, `.tfrec`
+- NumPy: `.npy`, `.npz`
 
 ## License
 
-Licensed under:
+This project is licensed under the Apache 2.0 License - see the LICENSE file for details.
 
-- Apache License, Version 2.0 ([LICENSE-APACHE](LICENSE-APACHE))
+## Contributing
+
+Contributions are welcome! Please feel free to submit a Pull Request.
+
+1. Fork the repository
+2. Create your feature branch (`git checkout -b feature/amazing-feature`)
+3. Commit your changes (`git commit -m 'Add amazing feature'`)
+4. Push to the branch (`git push origin feature/amazing-feature`)
+5. Open a Pull Request

--- a/benches/hash_benchmark.rs
+++ b/benches/hash_benchmark.rs
@@ -1,6 +1,6 @@
 //! Benchmarks for hash functionality
 
-use atlas_core::hash::{
+use atlas_common::hash::{
     calculate_hash, calculate_hash_with_algorithm, combine_hashes, verify_hash, HashAlgorithm,
     HashBuilder, Hasher,
 };
@@ -160,7 +160,7 @@ fn bench_default_vs_specific(c: &mut Criterion) {
 }
 
 fn bench_algorithm_detection(c: &mut Criterion) {
-    use atlas_core::hash::detect_hash_algorithm;
+    use atlas_common::hash::detect_hash_algorithm;
 
     let sha256_hash = "a".repeat(64);
     let sha384_hash = "b".repeat(96);
@@ -180,7 +180,7 @@ fn bench_algorithm_detection(c: &mut Criterion) {
 }
 
 fn bench_hash_validation(c: &mut Criterion) {
-    use atlas_core::hash::validate_hash_format;
+    use atlas_common::hash::validate_hash_format;
 
     let valid_hash = "a".repeat(96);
     let invalid_hash = "xyz123";

--- a/examples/basic_hashing.rs
+++ b/examples/basic_hashing.rs
@@ -1,10 +1,10 @@
 //! Example demonstrating hasxh functionality
 //! Run with: cargo run --example basic_hashing --features hash
 
-use atlas_core::hash::{
+use atlas_common::hash::{
     calculate_hash, calculate_hash_with_algorithm, HashAlgorithm, HashBuilder, Hasher,
 };
-use atlas_core::Result;
+use atlas_common::Result;
 
 fn main() -> Result<()> {
     // Basic hashing with default algorithm (SHA-384)
@@ -33,7 +33,7 @@ fn main() -> Result<()> {
     let data_to_verify = b"Important data";
     let expected_hash = calculate_hash(data_to_verify);
 
-    if atlas_core::hash::verify_hash(data_to_verify, &expected_hash) {
+    if atlas_common::hash::verify_hash(data_to_verify, &expected_hash) {
         println!("✓ Hash verification successful");
     } else {
         println!("✗ Hash verification failed");
@@ -42,7 +42,7 @@ fn main() -> Result<()> {
     // Combine multiple hashes
     let hash1 = calculate_hash(b"Dataset A");
     let hash2 = calculate_hash(b"Dataset B");
-    let combined = atlas_core::hash::combine_hashes(&[&hash1, &hash2])?;
+    let combined = atlas_common::hash::combine_hashes(&[&hash1, &hash2])?;
     println!("Combined hash: {}", combined);
 
     Ok(())

--- a/examples/c2pa_manifest.rs
+++ b/examples/c2pa_manifest.rs
@@ -1,11 +1,11 @@
 //! Example demonstrating C2PA manifest functionality
 //! Run with: cargo run --example c2pa_manifest --features c2pa
 
-use atlas_core::c2pa::{
+use atlas_common::c2pa::{
     determine_asset_type, determine_format, AssetKind, DateTimeWrapper, ManifestId,
     ManifestMetadata, ManifestType,
 };
-use atlas_core::Result;
+use atlas_common::Result;
 use std::path::Path;
 
 fn main() -> Result<()> {

--- a/examples/full_example.rs
+++ b/examples/full_example.rs
@@ -8,8 +8,8 @@ fn main() {
 }
 
 #[cfg(feature = "all")]
-fn main() -> atlas_core::Result<()> {
-    use atlas_core::{
+fn main() -> atlas_common::Result<()> {
+    use atlas_common::{
         c2pa::{determine_asset_type, AssetKind, ManifestId, ManifestMetadata, ManifestType},
         file::{safe_create_file, safe_open_file},
         hash::{calculate_hash, HashAlgorithm, Hasher},
@@ -153,14 +153,14 @@ fn main() -> atlas_core::Result<()> {
         id: manifest_id.as_urn().to_string(),
         name: "ResNet-50 Transfer Learning Model".to_string(),
         manifest_type: ManifestType::Model,
-        created_at: atlas_core::c2pa::DateTimeWrapper::now_utc().to_rfc3339(),
+        created_at: atlas_common::c2pa::DateTimeWrapper::now_utc().to_rfc3339(),
         hash: Some(model_hash),
         size: Some(98765432),
         version: Some("2.1.0".to_string()),
     };
 
     // Validate the metadata
-    atlas_core::validation::validate_manifest_metadata(&metadata)?;
+    atlas_common::validation::validate_manifest_metadata(&metadata)?;
     println!("✓ Manifest metadata validated");
 
     // Serialize to JSON
@@ -177,9 +177,9 @@ fn main() -> atlas_core::Result<()> {
     let test_hash_sha512 = "c".repeat(128);
 
     for hash in &[test_hash_sha256, test_hash_sha384, test_hash_sha512] {
-        match atlas_core::hash::validate_hash_format(hash) {
+        match atlas_common::hash::validate_hash_format(hash) {
             Ok(_) => {
-                let algo = atlas_core::hash::detect_hash_algorithm(hash);
+                let algo = atlas_common::hash::detect_hash_algorithm(hash);
                 println!("✓ Valid {} hash (length: {})", algo, hash.len());
             }
             Err(e) => println!("✗ Invalid hash: {}", e),
@@ -188,7 +188,7 @@ fn main() -> atlas_core::Result<()> {
 
     // Invalid hash
     let invalid_hash = "xyz123";
-    match atlas_core::hash::validate_hash_format(invalid_hash) {
+    match atlas_common::hash::validate_hash_format(invalid_hash) {
         Ok(_) => println!("✗ Should have rejected invalid hash"),
         Err(_) => println!("✓ Correctly rejected invalid hash format"),
     }

--- a/examples/full_example.rs
+++ b/examples/full_example.rs
@@ -1,19 +1,26 @@
 //! Example demonstrating full functionality with all features
 //! Run with: cargo run --example full_example --features full
 
-use atlas_core::{
-    c2pa::{determine_asset_type, AssetKind, ManifestId, ManifestMetadata, ManifestType},
-    file::{safe_create_file, safe_open_file},
-    hash::{calculate_hash, HashAlgorithm, Hasher},
-    storage::{StorageConfig, StorageType},
-    validation::{ensure_c2pa_urn, extract_uuid_from_urn, validate_manifest_id},
-    Error, Result,
-};
-use std::io::{Read, Write};
-use std::path::Path;
-use tempfile::tempdir;
+#[cfg(not(feature = "all"))]
+fn main() {
+    eprintln!("This example requires the 'full' feature to be enabled.");
+    eprintln!("Run with: cargo run --example full_example --features all");
+}
 
-fn main() -> Result<()> {
+#[cfg(feature = "all")]
+fn main() -> atlas_core::Result<()> {
+    use atlas_core::{
+        c2pa::{determine_asset_type, AssetKind, ManifestId, ManifestMetadata, ManifestType},
+        file::{safe_create_file, safe_open_file},
+        hash::{calculate_hash, HashAlgorithm, Hasher},
+        storage::{StorageConfig, StorageType},
+        validation::{ensure_c2pa_urn, extract_uuid_from_urn, validate_manifest_id},
+        Error,
+    };
+    use std::io::{Read, Write};
+    use std::path::Path;
+    use tempfile::tempdir;
+
     println!("Atlas Core Full Example\n");
     println!("=======================\n");
 

--- a/examples/full_example.rs
+++ b/examples/full_example.rs
@@ -3,7 +3,7 @@
 
 #[cfg(not(feature = "all"))]
 fn main() {
-    eprintln!("This example requires the 'full' feature to be enabled.");
+    eprintln!("This example requires the 'all' feature to be enabled.");
     eprintln!("Run with: cargo run --example full_example --features all");
 }
 

--- a/src/c2pa/asset.rs
+++ b/src/c2pa/asset.rs
@@ -100,14 +100,14 @@ pub enum AssetKind {
 /// # Example
 ///
 /// ```rust
-/// use atlas_core::c2pa::{determine_asset_type, AssetKind};
+/// use atlas_common::c2pa::{determine_asset_type, AssetKind};
 /// use std::path::Path;
 ///
 /// let asset_type = determine_asset_type(
 ///     Path::new("model.onnx"),
 ///     AssetKind::Model
 /// )?;
-/// # Ok::<(), atlas_core::Error>(())
+/// # Ok::<(), atlas_common::Error>(())
 /// ```
 pub fn determine_asset_type(path: &Path, kind: AssetKind) -> Result<AssetType> {
     match kind {
@@ -164,12 +164,12 @@ pub fn determine_dataset_type(path: &Path) -> Result<AssetType> {
 /// # Example
 ///
 /// ```rust
-/// use atlas_core::c2pa::determine_format;
+/// use atlas_common::c2pa::determine_format;
 /// use std::path::Path;
 ///
 /// let mime = determine_format(Path::new("model.onnx"))?;
 /// assert_eq!(mime, "application/onnx");
-/// # Ok::<(), atlas_core::Error>(())
+/// # Ok::<(), atlas_common::Error>(())
 /// ```
 pub fn determine_format(path: &Path) -> Result<String> {
     match path.extension().and_then(|ext| ext.to_str()) {

--- a/src/c2pa/asset.rs
+++ b/src/c2pa/asset.rs
@@ -7,52 +7,68 @@ use crate::error::{Error, Result};
 use serde::{Deserialize, Serialize};
 use std::path::Path;
 
-/// Types of assets in the C2PA framework
+/// C2PA asset types for machine learning artifacts
+///
+/// These types follow the C2PA naming convention for different asset categories.
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
 pub enum AssetType {
     // Datasets
+    /// Generic dataset
     #[serde(rename = "c2pa.types.dataset")]
     Dataset,
 
+    /// TensorFlow dataset format
     #[serde(rename = "c2pa.types.dataset.tensorflow")]
     DatasetTensorFlow,
 
+    /// PyTorch dataset format
     #[serde(rename = "c2pa.types.dataset.pytorch")]
     DatasetPyTorch,
 
+    /// ONNX dataset format
     #[serde(rename = "c2pa.types.dataset.onnx")]
     DatasetOnnx,
 
     // Models
+    /// Generic model
     #[serde(rename = "c2pa.types.model")]
     Model,
 
+    /// TensorFlow model
     #[serde(rename = "c2pa.types.model.tensorflow")]
     ModelTensorFlow,
 
+    /// PyTorch model
     #[serde(rename = "c2pa.types.model.pytorch")]
     ModelPyTorch,
 
+    /// ONNX model
     #[serde(rename = "c2pa.types.model.onnx")]
     ModelOnnx,
 
+    /// OpenVINO model
     #[serde(rename = "c2pa.types.model.openvino")]
     ModelOpenVino,
 
     // Software
+    /// Software/code artifact
     #[serde(rename = "c2pa.types.software")]
     Software,
 
+    /// Generator/tool artifact
     #[serde(rename = "c2pa.types.generator")]
     Generator,
 
     // Formats
+    /// NumPy array format
     #[serde(rename = "c2pa.types.format.numpy")]
     FormatNumpy,
 
+    /// Python pickle format
     #[serde(rename = "c2pa.types.format.pickle")]
     FormatPickle,
 
+    /// Protocol buffer format
     #[serde(rename = "c2pa.types.format.protobuf")]
     FormatProtobuf,
 }
@@ -60,13 +76,39 @@ pub enum AssetType {
 /// High-level classification of assets
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub enum AssetKind {
+    /// Machine learning model
     Model,
+    /// Training or evaluation dataset
     Dataset,
+    /// Software or code
     Software,
+    /// Evaluation results or benchmarks
     Evaluation,
 }
 
 /// Determine the asset type based on file path and kind
+///
+/// # Arguments
+///
+/// * `path` - File path to analyze
+/// * `kind` - High-level asset classification
+///
+/// # Errors
+///
+/// Returns an error if the file has no extension.
+///
+/// # Example
+///
+/// ```rust
+/// use atlas_core::c2pa::{determine_asset_type, AssetKind};
+/// use std::path::Path;
+///
+/// let asset_type = determine_asset_type(
+///     Path::new("model.onnx"),
+///     AssetKind::Model
+/// )?;
+/// # Ok::<(), atlas_core::Error>(())
+/// ```
 pub fn determine_asset_type(path: &Path, kind: AssetKind) -> Result<AssetType> {
     match kind {
         AssetKind::Model => determine_model_type(path),
@@ -77,6 +119,10 @@ pub fn determine_asset_type(path: &Path, kind: AssetKind) -> Result<AssetType> {
 }
 
 /// Determine the specific model type from a file path
+///
+/// # Errors
+///
+/// Returns an error if the file has no extension.
 pub fn determine_model_type(path: &Path) -> Result<AssetType> {
     match path.extension().and_then(|ext| ext.to_str()) {
         Some("pb") | Some("savedmodel") | Some("tf") => Ok(AssetType::ModelTensorFlow),
@@ -93,6 +139,10 @@ pub fn determine_model_type(path: &Path) -> Result<AssetType> {
 }
 
 /// Determine the specific dataset type from a file path
+///
+/// # Errors
+///
+/// Returns an error if the file has no extension.
 pub fn determine_dataset_type(path: &Path) -> Result<AssetType> {
     match path.extension().and_then(|ext| ext.to_str()) {
         Some("csv") | Some("tsv") | Some("txt") => Ok(AssetType::Dataset),
@@ -108,6 +158,19 @@ pub fn determine_dataset_type(path: &Path) -> Result<AssetType> {
 }
 
 /// Determine the MIME type from a file path
+///
+/// Returns appropriate MIME types for ML-related file formats.
+///
+/// # Example
+///
+/// ```rust
+/// use atlas_core::c2pa::determine_format;
+/// use std::path::Path;
+///
+/// let mime = determine_format(Path::new("model.onnx"))?;
+/// assert_eq!(mime, "application/onnx");
+/// # Ok::<(), atlas_core::Error>(())
+/// ```
 pub fn determine_format(path: &Path) -> Result<String> {
     match path.extension().and_then(|ext| ext.to_str()) {
         Some("pb") => Ok("application/x-protobuf".to_string()),

--- a/src/c2pa/asset.rs
+++ b/src/c2pa/asset.rs
@@ -59,10 +59,10 @@ pub enum AssetType {
     #[serde(rename = "c2pa.types.generator")]
     Generator,
 
-    // Formats
+    // SerializationFormats
     /// NumPy array format
-    #[serde(rename = "c2pa.types.format.numpy")]
-    FormatNumpy,
+    #[serde(rename = "c2pa.types.numpy")]
+    SerializationNumpy
 
     /// Python pickle format
     #[serde(rename = "c2pa.types.format.pickle")]

--- a/src/c2pa/datetime.rs
+++ b/src/c2pa/datetime.rs
@@ -16,7 +16,7 @@ impl DateTimeWrapper {
     /// # Example
     ///
     /// ```rust
-    /// use atlas_core::c2pa::DateTimeWrapper;
+    /// use atlas_common::c2pa::DateTimeWrapper;
     ///
     /// let now = DateTimeWrapper::now_utc();
     /// println!("Current time: {}", now.to_rfc3339());

--- a/src/c2pa/datetime.rs
+++ b/src/c2pa/datetime.rs
@@ -1,18 +1,39 @@
+//! Date and time handling for C2PA manifests
+
 use crate::error::{Error, Result};
 use serde::{Deserialize, Serialize};
 use time::OffsetDateTime;
 
-/// Wrapper for OffsetDateTime with serde support
+/// Wrapper for OffsetDateTime with serde support and validation
+///
+/// Ensures timestamps are valid and in the correct format for C2PA manifests.
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
 pub struct DateTimeWrapper(#[serde(with = "time::serde::rfc3339")] pub OffsetDateTime);
 
 impl DateTimeWrapper {
     /// Create new with current UTC time
+    ///
+    /// # Example
+    ///
+    /// ```rust
+    /// use atlas_core::c2pa::DateTimeWrapper;
+    ///
+    /// let now = DateTimeWrapper::now_utc();
+    /// println!("Current time: {}", now.to_rfc3339());
+    /// ```
     pub fn now_utc() -> Self {
         Self(OffsetDateTime::now_utc())
     }
 
-    /// Validate datetime
+    /// Validate that the datetime is reasonable
+    ///
+    /// Checks that:
+    /// - The date is after January 1, 1970
+    /// - The date is not in the future
+    ///
+    /// # Errors
+    ///
+    /// Returns an error if validation fails.
     pub fn validate(&self) -> Result<()> {
         if self.0.year() < 1970 {
             return Err(Error::Time(
@@ -29,6 +50,8 @@ impl DateTimeWrapper {
     }
 
     /// Get as RFC3339 string
+    ///
+    /// Returns the datetime formatted according to RFC3339 standard.
     pub fn to_rfc3339(&self) -> String {
         self.0
             .format(&time::format_description::well_known::Rfc3339)

--- a/src/c2pa/manifest.rs
+++ b/src/c2pa/manifest.rs
@@ -97,7 +97,7 @@ pub struct ManifestMetadata {
 /// # Example
 ///
 /// ```rust
-/// use atlas_core::c2pa::ManifestId;
+/// use atlas_common::c2pa::ManifestId;
 ///
 /// // Create new ID
 /// let id = ManifestId::new();
@@ -109,7 +109,7 @@ pub struct ManifestMetadata {
 ///
 /// // Create versioned ID
 /// let versioned = id.with_version(2, 1);
-/// # Ok::<(), atlas_core::Error>(())
+/// # Ok::<(), atlas_common::Error>(())
 /// ```
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
 pub struct ManifestId {
@@ -138,12 +138,12 @@ impl ManifestId {
     /// # Example
     ///
     /// ```rust
-    /// use atlas_core::c2pa::ManifestId;
+    /// use atlas_common::c2pa::ManifestId;
     ///
     /// let id = ManifestId::from_urn(
     ///     "urn:c2pa:123e4567-e89b-12d3-a456-426614174000:adobe:2_1"
     /// )?;
-    /// # Ok::<(), atlas_core::Error>(())
+    /// # Ok::<(), atlas_common::Error>(())
     /// ```
     pub fn from_urn(urn: &str) -> crate::error::Result<Self> {
         let parts: Vec<&str> = urn.split(':').collect();
@@ -202,7 +202,7 @@ impl ManifestId {
     /// # Example
     ///
     /// ```rust
-    /// use atlas_core::c2pa::ManifestId;
+    /// use atlas_common::c2pa::ManifestId;
     ///
     /// let id = ManifestId::new();
     /// let v2 = id.with_version(2, 1); // Version 2, reason 1

--- a/src/c2pa/manifest.rs
+++ b/src/c2pa/manifest.rs
@@ -1,23 +1,35 @@
+//! C2PA manifest types and identifiers
 use serde::{Deserialize, Serialize};
 use std::fmt;
 use uuid::Uuid;
 
-/// Types of manifests
+/// Types of manifests in the C2PA framework
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
 pub enum ManifestType {
+    /// Dataset manifest
     #[serde(rename = "dataset")]
     Dataset,
+
+    /// Machine learning model manifest
     #[serde(rename = "model")]
     Model,
+
+    /// Software/code manifest
     #[serde(rename = "software")]
     Software,
+
+    /// Evaluation/benchmark manifest
     #[serde(rename = "evaluation")]
     Evaluation,
+
+    /// Unknown or unspecified type
     #[serde(rename = "unknown")]
     Unknown,
 }
 
 impl ManifestType {
+    /// Get the manifest type as a string
+
     pub fn as_str(&self) -> &'static str {
         match self {
             ManifestType::Dataset => "dataset",
@@ -49,19 +61,56 @@ impl std::str::FromStr for ManifestType {
     }
 }
 
-/// Manifest metadata
+/// Metadata for a C2PA manifest
+///
+/// Contains all the essential information about a manifest including
+/// its identifier, type, creation time, and optional hash and size.
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct ManifestMetadata {
+    /// Unique identifier (URN format)
     pub id: String,
+
+    /// Human-readable name
     pub name: String,
+
+    /// Type of manifest
     pub manifest_type: ManifestType,
+
+    /// Creation timestamp (RFC3339 format)
     pub created_at: String,
+
+    /// Optional cryptographic hash
     pub hash: Option<String>,
+
+    /// Optional size in bytes
     pub size: Option<u64>,
+
+    /// Optional version string
     pub version: Option<String>,
 }
 
-/// Manifest identifier
+/// C2PA manifest identifier
+///
+/// Represents a unique identifier for C2PA manifests in URN format.
+/// Format: `urn:c2pa:UUID[:claim_generator[:version_reason]]`
+///
+/// # Example
+///
+/// ```rust
+/// use atlas_core::c2pa::ManifestId;
+///
+/// // Create new ID
+/// let id = ManifestId::new();
+///
+/// // Parse existing URN
+/// let parsed = ManifestId::from_urn(
+///     "urn:c2pa:123e4567-e89b-12d3-a456-426614174000"
+/// )?;
+///
+/// // Create versioned ID
+/// let versioned = id.with_version(2, 1);
+/// # Ok::<(), atlas_core::Error>(())
+/// ```
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
 pub struct ManifestId {
     urn: String,
@@ -71,7 +120,7 @@ pub struct ManifestId {
 }
 
 impl ManifestId {
-    /// Create a new manifest ID
+    /// Create a new manifest ID with a random UUID
     pub fn new() -> Self {
         Self {
             urn: format!("urn:c2pa:{}", Uuid::new_v4()),
@@ -80,8 +129,22 @@ impl ManifestId {
             version: None,
         }
     }
-
-    /// Create from URN string
+    /// Create a manifest ID from a URN string
+    ///
+    /// # Errors
+    ///
+    /// Returns an error if the URN format is invalid or the UUID cannot be parsed.
+    ///
+    /// # Example
+    ///
+    /// ```rust
+    /// use atlas_core::c2pa::ManifestId;
+    ///
+    /// let id = ManifestId::from_urn(
+    ///     "urn:c2pa:123e4567-e89b-12d3-a456-426614174000:adobe:2_1"
+    /// )?;
+    /// # Ok::<(), atlas_core::Error>(())
+    /// ```
     pub fn from_urn(urn: &str) -> crate::error::Result<Self> {
         let parts: Vec<&str> = urn.split(':').collect();
 
@@ -119,17 +182,31 @@ impl ManifestId {
         })
     }
 
-    /// Get as URN string
+    /// Get the URN string representation
     pub fn as_urn(&self) -> &str {
         &self.urn
     }
 
-    /// Get UUID
+    /// Get the UUID component
     pub fn uuid(&self) -> &Uuid {
         &self.uuid
     }
 
-    /// Create a versioned ID
+    /// Create a versioned variant of this ID
+    ///
+    /// # Arguments
+    ///
+    /// * `version` - Version number
+    /// * `reason` - Reason code for the version
+    ///
+    /// # Example
+    ///
+    /// ```rust
+    /// use atlas_core::c2pa::ManifestId;
+    ///
+    /// let id = ManifestId::new();
+    /// let v2 = id.with_version(2, 1); // Version 2, reason 1
+    /// ```
     pub fn with_version(&self, version: u32, reason: u32) -> Self {
         let claim_gen = self.claim_generator.as_deref().unwrap_or("unknown");
         let urn = format!(

--- a/src/c2pa/mod.rs
+++ b/src/c2pa/mod.rs
@@ -14,7 +14,7 @@
 //! # Example
 //!
 //! ```rust
-//! use atlas_core::c2pa::{
+//! use atlas_common::c2pa::{
 //!     ManifestId, ManifestMetadata, ManifestType,
 //!     determine_asset_type, AssetKind
 //! };
@@ -27,7 +27,7 @@
 //! // Determine asset type
 //! let model_path = Path::new("model.onnx");
 //! let asset_type = determine_asset_type(model_path, AssetKind::Model)?;
-//! # Ok::<(), atlas_core::Error>(())
+//! # Ok::<(), atlas_common::Error>(())
 //! ```
 mod asset;
 mod datetime;

--- a/src/c2pa/mod.rs
+++ b/src/c2pa/mod.rs
@@ -1,9 +1,34 @@
-//! C2PA manifest and asset types
+//! C2PA (Coalition for Content Provenance and Authenticity) support
 //!
-//! This module provides types and utilities for working with C2PA
-//! (Coalition for Content Provenance and Authenticity) manifests
-//! and assets in machine learning contexts.
-
+//! This module provides types and utilities for working with C2PA manifests
+//! and assets in machine learning contexts. C2PA is a standard for establishing
+//! the provenance and authenticity of digital content.
+//!
+//! # Key Components
+//!
+//! - **ManifestId**: Unique identifiers for C2PA manifests
+//! - **ManifestMetadata**: Metadata structure for manifests
+//! - **AssetType**: Classification of ML assets (models, datasets, etc.)
+//! - **DateTimeWrapper**: Time handling with validation
+//!
+//! # Example
+//!
+//! ```rust
+//! use atlas_core::c2pa::{
+//!     ManifestId, ManifestMetadata, ManifestType,
+//!     determine_asset_type, AssetKind
+//! };
+//! use std::path::Path;
+//!
+//! // Create a manifest ID
+//! let id = ManifestId::new();
+//! println!("URN: {}", id.as_urn());
+//!
+//! // Determine asset type
+//! let model_path = Path::new("model.onnx");
+//! let asset_type = determine_asset_type(model_path, AssetKind::Model)?;
+//! # Ok::<(), atlas_core::Error>(())
+//! ```
 mod asset;
 mod datetime;
 mod manifest;

--- a/src/error.rs
+++ b/src/error.rs
@@ -1,54 +1,114 @@
+//! Error types for Atlas Core
+//!
+//! This module defines the error types used throughout the Atlas Core library.
+//! All errors are unified under a single `Error` enum for consistent error handling.
 use thiserror::Error;
 
+/// Main error type for Atlas Core operations
+///
+/// This enum represents all possible errors that can occur in the Atlas Core library.
+/// It uses the `thiserror` crate for automatic `Error` trait implementation.
 #[derive(Error, Debug)]
 pub enum Error {
+    /// I/O operation error
     #[error("IO error: {0}")]
     Io(#[from] std::io::Error),
 
+    /// Storage backend error
     #[error("Storage error: {0}")]
     Storage(String),
 
+    /// Validation error for invalid data or formats
     #[error("Validation error: {0}")]
     Validation(String),
 
+    /// Hash operation or verification error
     #[error("Hash error: {0}")]
     Hash(String),
 
+    /// Serialization/deserialization error
     #[error("Serialization error: {0}")]
     Serialization(String),
 
+    /// Hex decoding error (only with `hash` feature)
     #[cfg(feature = "hash")]
     #[error("Hex decode error: {0}")]
     HexDecode(#[from] hex::FromHexError),
 
+    /// JSON processing error
     #[error("JSON error: {0}")]
     Json(#[from] serde_json::Error),
 
+    /// Time/datetime related error
     #[error("Time error: {0}")]
     Time(String),
 
+    /// Resource not found error
     #[error("Not found: {0}")]
     NotFound(String),
 
+    /// Resource already exists error
     #[error("Already exists: {0}")]
     AlreadyExists(String),
 
+    /// Invalid format error
     #[error("Invalid format: {0}")]
     InvalidFormat(String),
 
+    /// Unsupported operation error
     #[error("Unsupported operation: {0}")]
     Unsupported(String),
 }
 
+/// Result type alias for Atlas Core operations
+///
+/// This type alias provides a convenient way to return results from Atlas Core functions.
+///
+/// # Example
+///
+/// ```rust
+/// use atlas_core::Result;
+///
+/// fn process_data() -> Result<String> {
+///     Ok("processed".to_string())
+/// }
+/// ```
 pub type Result<T> = std::result::Result<T, Error>;
 
 impl Error {
-    /// Check if error is retriable
+    /// Check if the error is retriable
+    ///
+    /// Returns `true` for transient errors that might succeed on retry,
+    /// such as I/O or storage errors.
+    ///
+    /// # Example
+    ///
+    /// ```rust
+    /// use atlas_core::Error;
+    ///
+    /// let error = Error::Io(std::io::Error::new(
+    ///     std::io::ErrorKind::TimedOut,
+    ///     "timeout"
+    /// ));
+    /// assert!(error.is_retriable());
+    /// ```
     pub fn is_retriable(&self) -> bool {
         matches!(self, Error::Io(_) | Error::Storage(_))
     }
 
-    /// Get error code for API responses
+    /// Get a stable error code for API responses
+    ///
+    /// Returns a constant string identifier for each error variant,
+    /// useful for API error responses.
+    ///
+    /// # Example
+    ///
+    /// ```rust
+    /// use atlas_core::Error;
+    ///
+    /// let error = Error::NotFound("manifest".to_string());
+    /// assert_eq!(error.error_code(), "NOT_FOUND");
+    /// ```
     pub fn error_code(&self) -> &'static str {
         match self {
             Error::Io(_) => "IO_ERROR",

--- a/src/error.rs
+++ b/src/error.rs
@@ -67,7 +67,7 @@ pub enum Error {
 /// # Example
 ///
 /// ```rust
-/// use atlas_core::Result;
+/// use atlas_common::Result;
 ///
 /// fn process_data() -> Result<String> {
 ///     Ok("processed".to_string())
@@ -84,7 +84,7 @@ impl Error {
     /// # Example
     ///
     /// ```rust
-    /// use atlas_core::Error;
+    /// use atlas_common::Error;
     ///
     /// let error = Error::Io(std::io::Error::new(
     ///     std::io::ErrorKind::TimedOut,
@@ -104,7 +104,7 @@ impl Error {
     /// # Example
     ///
     /// ```rust
-    /// use atlas_core::Error;
+    /// use atlas_common::Error;
     ///
     /// let error = Error::NotFound("manifest".to_string());
     /// assert_eq!(error.error_code(), "NOT_FOUND");

--- a/src/file/mod.rs
+++ b/src/file/mod.rs
@@ -2,6 +2,31 @@
 //!
 //! This module provides safe file operations that protect against common
 //! security issues like symlink attacks and hard link manipulation.
+//!
+//! # Security Features
+//!
+//! - Symlink attack prevention
+//! - Hard link detection
+//! - Path validation
+//! - Safe file creation and opening
+//!
+//! # Example
+//!
+//! ```rust,no_run
+//! use atlas_core::file::{safe_create_file, safe_open_file};
+//! use std::io::{Read, Write};
+//! use std::path::Path;
+//!
+//! // Safely create a file
+//! let mut file = safe_create_file(Path::new("output.txt"), false)?;
+//! file.write_all(b"secure data")?;
+//!
+//! // Safely read a file
+//! let mut file = safe_open_file(Path::new("input.txt"), false)?;
+//! let mut contents = String::new();
+//! file.read_to_string(&mut contents)?;
+//! # Ok::<(), atlas_core::Error>(())
+//! ```
 
 mod security;
 

--- a/src/file/mod.rs
+++ b/src/file/mod.rs
@@ -13,7 +13,7 @@
 //! # Example
 //!
 //! ```rust,no_run
-//! use atlas_core::file::{safe_create_file, safe_open_file};
+//! use atlas_common::file::{safe_create_file, safe_open_file};
 //! use std::io::{Read, Write};
 //! use std::path::Path;
 //!
@@ -25,7 +25,7 @@
 //! let mut file = safe_open_file(Path::new("input.txt"), false)?;
 //! let mut contents = String::new();
 //! file.read_to_string(&mut contents)?;
-//! # Ok::<(), atlas_core::Error>(())
+//! # Ok::<(), atlas_common::Error>(())
 //! ```
 
 mod security;

--- a/src/file/security.rs
+++ b/src/file/security.rs
@@ -1,3 +1,5 @@
+//! Security-focused file operations
+
 use crate::error::{Error, Result};
 use std::fs::{File, OpenOptions};
 use std::path::{Path, PathBuf};
@@ -8,6 +10,25 @@ use std::path::{Path, PathBuf};
 /// - Unauthorized symlink traversal
 /// - Hard link attacks
 /// - Access to restricted directories
+///
+/// # Arguments
+///
+/// * `path` - Path to validate
+/// * `allow_symlinks` - Whether to allow symlinks
+///
+/// # Errors
+///
+/// Returns an error if the path is unsafe.
+///
+/// # Example
+///
+/// ```rust,no_run
+/// use atlas_core::file::safe_file_path;
+/// use std::path::Path;
+///
+/// let safe_path = safe_file_path(Path::new("data.txt"), false)?;
+/// # Ok::<(), atlas_core::Error>(())
+/// ```
 pub fn safe_file_path(path: &Path, allow_symlinks: bool) -> Result<PathBuf> {
     if path.exists() {
         // Check for symlinks
@@ -52,6 +73,8 @@ pub fn safe_file_path(path: &Path, allow_symlinks: bool) -> Result<PathBuf> {
 }
 
 /// Validates that a symlink target is in an allowed location
+///
+/// Currently allows /tmp and /var/app/data directories.
 fn is_safe_symlink_target(target: &Path) -> bool {
     if let Ok(canonical) = target.canonicalize() {
         canonical.starts_with("/tmp") || canonical.starts_with("/var/app/data")
@@ -61,18 +84,68 @@ fn is_safe_symlink_target(target: &Path) -> bool {
 }
 
 /// Safely opens a file for reading with security checks
+///
+/// # Arguments
+///
+/// * `path` - Path to the file
+/// * `allow_symlinks` - Whether to allow symlinks
+///
+/// # Errors
+///
+/// Returns an error if the file cannot be opened safely.
+///
+/// # Example
+///
+/// ```rust,no_run
+/// use atlas_core::file::safe_open_file;
+/// use std::path::Path;
+///
+/// let file = safe_open_file(Path::new("data.txt"), false)?;
+/// # Ok::<(), atlas_core::Error>(())
+/// ```
 pub fn safe_open_file(path: &Path, allow_symlinks: bool) -> Result<File> {
     let safe_path = safe_file_path(path, allow_symlinks)?;
     File::open(&safe_path).map_err(Error::from)
 }
 
 /// Safely creates a file for writing with security checks
+///
+/// # Arguments
+///
+/// * `path` - Path to the file
+/// * `allow_symlinks` - Whether to allow symlinks
+///
+/// # Errors
+///
+/// Returns an error if the file cannot be created safely.
+///
+/// # Example
+///
+/// ```rust,no_run
+/// use atlas_core::file::safe_create_file;
+/// use std::path::Path;
+///
+/// let file = safe_create_file(Path::new("output.txt"), false)?;
+/// # Ok::<(), atlas_core::Error>(())
+/// ```
 pub fn safe_create_file(path: &Path, allow_symlinks: bool) -> Result<File> {
     let safe_path = safe_file_path(path, allow_symlinks)?;
     File::create(&safe_path).map_err(Error::from)
 }
 
 /// Creates `OpenOptions` for a file with security validation
+///
+/// Returns configured `OpenOptions` that can be further customized
+/// before opening the file.
+///
+/// # Arguments
+///
+/// * `path` - Path to the file
+/// * `allow_symlinks` - Whether to allow symlinks
+///
+/// # Errors
+///
+/// Returns an error if the path is unsafe.
 pub fn safe_open_options(path: &Path, allow_symlinks: bool) -> Result<OpenOptions> {
     let _safe_path = safe_file_path(path, allow_symlinks)?;
     Ok(OpenOptions::new())

--- a/src/file/security.rs
+++ b/src/file/security.rs
@@ -23,11 +23,11 @@ use std::path::{Path, PathBuf};
 /// # Example
 ///
 /// ```rust,no_run
-/// use atlas_core::file::safe_file_path;
+/// use atlas_common::file::safe_file_path;
 /// use std::path::Path;
 ///
 /// let safe_path = safe_file_path(Path::new("data.txt"), false)?;
-/// # Ok::<(), atlas_core::Error>(())
+/// # Ok::<(), atlas_common::Error>(())
 /// ```
 pub fn safe_file_path(path: &Path, allow_symlinks: bool) -> Result<PathBuf> {
     if path.exists() {
@@ -97,11 +97,11 @@ fn is_safe_symlink_target(target: &Path) -> bool {
 /// # Example
 ///
 /// ```rust,no_run
-/// use atlas_core::file::safe_open_file;
+/// use atlas_common::file::safe_open_file;
 /// use std::path::Path;
 ///
 /// let file = safe_open_file(Path::new("data.txt"), false)?;
-/// # Ok::<(), atlas_core::Error>(())
+/// # Ok::<(), atlas_common::Error>(())
 /// ```
 pub fn safe_open_file(path: &Path, allow_symlinks: bool) -> Result<File> {
     let safe_path = safe_file_path(path, allow_symlinks)?;
@@ -122,11 +122,11 @@ pub fn safe_open_file(path: &Path, allow_symlinks: bool) -> Result<File> {
 /// # Example
 ///
 /// ```rust,no_run
-/// use atlas_core::file::safe_create_file;
+/// use atlas_common::file::safe_create_file;
 /// use std::path::Path;
 ///
 /// let file = safe_create_file(Path::new("output.txt"), false)?;
-/// # Ok::<(), atlas_core::Error>(())
+/// # Ok::<(), atlas_common::Error>(())
 /// ```
 pub fn safe_create_file(path: &Path, allow_symlinks: bool) -> Result<File> {
     let safe_path = safe_file_path(path, allow_symlinks)?;

--- a/src/hash/algorithms.rs
+++ b/src/hash/algorithms.rs
@@ -1,21 +1,36 @@
+//! Hash algorithm definitions and traits
+
 use crate::error::{Error, Result};
 use serde::{Deserialize, Serialize};
 use std::fmt;
 use std::str::FromStr;
 
-/// Supported hash algorithms
+/// Supported cryptographic hash algorithms
+///
+/// All algorithms use the SHA-2 family for security and performance.
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
 pub enum HashAlgorithm {
+    /// SHA-256 (256-bit/32-byte output)
     #[serde(rename = "sha256")]
     Sha256,
+    /// SHA-384 (384-bit/48-byte output) - Default
     #[serde(rename = "sha384")]
     Sha384,
+    /// SHA-512 (512-bit/64-byte output)
     #[serde(rename = "sha512")]
     Sha512,
 }
 
 impl HashAlgorithm {
     /// Get algorithm name as string
+    ///
+    /// # Example
+    ///
+    /// ```rust
+    /// use atlas_core::hash::HashAlgorithm;
+    ///
+    /// assert_eq!(HashAlgorithm::Sha256.as_str(), "sha256");
+    /// ```
     pub fn as_str(&self) -> &'static str {
         match self {
             HashAlgorithm::Sha256 => "sha256",
@@ -25,6 +40,15 @@ impl HashAlgorithm {
     }
 
     /// Get the output size in bytes
+    ///
+    /// # Example
+    ///
+    /// ```rust
+    /// use atlas_core::hash::HashAlgorithm;
+    ///
+    /// assert_eq!(HashAlgorithm::Sha256.output_size(), 32);
+    /// assert_eq!(HashAlgorithm::Sha512.output_size(), 64);
+    /// ```
     pub fn output_size(&self) -> usize {
         match self {
             HashAlgorithm::Sha256 => 32,
@@ -34,11 +58,29 @@ impl HashAlgorithm {
     }
 
     /// Get the output size in hex characters
+    ///
+    /// # Example
+    ///
+    /// ```rust
+    /// use atlas_core::hash::HashAlgorithm;
+    ///
+    /// assert_eq!(HashAlgorithm::Sha256.hex_length(), 64);
+    /// ```
     pub fn hex_length(&self) -> usize {
         self.output_size() * 2
     }
 
-    /// Check if a hash string matches this algorithm's expected length
+    /// Check if a hash string matches this algorithm's expected format
+    ///
+    /// # Example
+    ///
+    /// ```rust
+    /// use atlas_core::hash::HashAlgorithm;
+    ///
+    /// let hash = "a".repeat(64);
+    /// assert!(HashAlgorithm::Sha256.validate_hash(&hash));
+    /// assert!(!HashAlgorithm::Sha384.validate_hash(&hash));
+    /// ```
     pub fn validate_hash(&self, hash: &str) -> bool {
         hash.len() == self.hex_length() && hash.chars().all(|c| c.is_ascii_hexdigit())
     }
@@ -58,7 +100,10 @@ impl fmt::Display for HashAlgorithm {
 
 impl FromStr for HashAlgorithm {
     type Err = Error;
-
+    /// Parse algorithm from string
+    ///
+    /// Accepts: "sha256", "sha-256", "sha384", "sha-384", "sha512", "sha-512"
+    /// (case-insensitive)
     fn from_str(s: &str) -> Result<Self> {
         match s.to_lowercase().as_str() {
             "sha256" | "sha-256" => Ok(HashAlgorithm::Sha256),
@@ -72,7 +117,20 @@ impl FromStr for HashAlgorithm {
     }
 }
 
-/// Hash builder for incremental hashing
+/// Builder for incremental hashing
+///
+/// Useful when hashing data that arrives in chunks or from multiple sources.
+///
+/// # Example
+///
+/// ```rust
+/// use atlas_core::hash::{HashBuilder, HashAlgorithm};
+///
+/// let mut builder = HashBuilder::new(HashAlgorithm::Sha256);
+/// builder.update(b"part1");
+/// builder.update(b"part2");
+/// let hash = builder.finalize();
+/// ```
 pub struct HashBuilder {
     algorithm: HashAlgorithm,
     hasher: HashBuilderInner,
@@ -85,7 +143,7 @@ enum HashBuilderInner {
 }
 
 impl HashBuilder {
-    /// Create a new hash builder
+    /// Create a new hash builder with the specified algorith
     pub fn new(algorithm: HashAlgorithm) -> Self {
         use sha2::Digest;
 
@@ -99,6 +157,8 @@ impl HashBuilder {
     }
 
     /// Update the hash with more data
+    ///
+    /// Can be called multiple times to add data incrementally.
     pub fn update(&mut self, data: &[u8]) {
         use sha2::Digest;
 
@@ -109,7 +169,9 @@ impl HashBuilder {
         }
     }
 
-    /// Finalize and get the hash
+    /// Finalize and get the hash as a hex string
+    ///
+    /// Consumes the builder.
     pub fn finalize(self) -> String {
         use sha2::Digest;
 
@@ -127,6 +189,20 @@ impl HashBuilder {
 }
 
 /// Trait for types that can be hashed
+///
+/// Implemented for `[u8]`, `str`, and `String`.
+///
+/// # Example
+///
+/// ```rust
+/// use atlas_core::hash::{Hasher, HashAlgorithm};
+///
+/// let text = "Hello, World!";
+/// let hash = text.hash(HashAlgorithm::Sha256);
+///
+/// let bytes = b"raw bytes";
+/// let hash2 = bytes.hash(HashAlgorithm::Sha512);
+/// ```
 pub trait Hasher {
     fn hash(&self, algorithm: HashAlgorithm) -> String;
     fn hash_default(&self) -> String {

--- a/src/hash/algorithms.rs
+++ b/src/hash/algorithms.rs
@@ -27,7 +27,7 @@ impl HashAlgorithm {
     /// # Example
     ///
     /// ```rust
-    /// use atlas_core::hash::HashAlgorithm;
+    /// use atlas_common::hash::HashAlgorithm;
     ///
     /// assert_eq!(HashAlgorithm::Sha256.as_str(), "sha256");
     /// ```
@@ -44,7 +44,7 @@ impl HashAlgorithm {
     /// # Example
     ///
     /// ```rust
-    /// use atlas_core::hash::HashAlgorithm;
+    /// use atlas_common::hash::HashAlgorithm;
     ///
     /// assert_eq!(HashAlgorithm::Sha256.output_size(), 32);
     /// assert_eq!(HashAlgorithm::Sha512.output_size(), 64);
@@ -62,7 +62,7 @@ impl HashAlgorithm {
     /// # Example
     ///
     /// ```rust
-    /// use atlas_core::hash::HashAlgorithm;
+    /// use atlas_common::hash::HashAlgorithm;
     ///
     /// assert_eq!(HashAlgorithm::Sha256.hex_length(), 64);
     /// ```
@@ -75,7 +75,7 @@ impl HashAlgorithm {
     /// # Example
     ///
     /// ```rust
-    /// use atlas_core::hash::HashAlgorithm;
+    /// use atlas_common::hash::HashAlgorithm;
     ///
     /// let hash = "a".repeat(64);
     /// assert!(HashAlgorithm::Sha256.validate_hash(&hash));
@@ -124,7 +124,7 @@ impl FromStr for HashAlgorithm {
 /// # Example
 ///
 /// ```rust
-/// use atlas_core::hash::{HashBuilder, HashAlgorithm};
+/// use atlas_common::hash::{HashBuilder, HashAlgorithm};
 ///
 /// let mut builder = HashBuilder::new(HashAlgorithm::Sha256);
 /// builder.update(b"part1");
@@ -195,7 +195,7 @@ impl HashBuilder {
 /// # Example
 ///
 /// ```rust
-/// use atlas_core::hash::{Hasher, HashAlgorithm};
+/// use atlas_common::hash::{Hasher, HashAlgorithm};
 ///
 /// let text = "Hello, World!";
 /// let hash = text.hash(HashAlgorithm::Sha256);

--- a/src/hash/mod.rs
+++ b/src/hash/mod.rs
@@ -14,14 +14,14 @@
 //! # Example
 //!
 //! ```rust
-//! use atlas_core::hash::{calculate_hash, verify_hash, HashAlgorithm};
+//! use atlas_common::hash::{calculate_hash, verify_hash, HashAlgorithm};
 //!
 //! let data = b"important data";
 //! let hash = calculate_hash(data);
 //! assert!(verify_hash(data, &hash));
 //!
 //! // Use specific algorithm
-//! let sha256_hash = atlas_core::hash::calculate_hash_with_algorithm(
+//! let sha256_hash = atlas_common::hash::calculate_hash_with_algorithm(
 //!     data,
 //!     &HashAlgorithm::Sha256
 //! );
@@ -55,7 +55,7 @@ pub fn calculate_hash_with_algorithm(data: &[u8], algorithm: &HashAlgorithm) -> 
 /// # Example
 ///
 /// ```rust
-/// use atlas_core::hash::calculate_hash;
+/// use atlas_common::hash::calculate_hash;
 ///
 /// let data = b"test data";
 /// let hash = calculate_hash(data);
@@ -70,7 +70,7 @@ pub fn calculate_file_hash(path: impl AsRef<Path>) -> Result<String> {
 /// # Example
 ///
 /// ```rust
-/// use atlas_core::hash::{calculate_hash_with_algorithm, HashAlgorithm};
+/// use atlas_common::hash::{calculate_hash_with_algorithm, HashAlgorithm};
 ///
 /// let data = b"test data";
 /// let sha256_hash = calculate_hash_with_algorithm(data, &HashAlgorithm::Sha256);
@@ -100,12 +100,12 @@ pub fn calculate_file_hash_with_algorithm(
 /// # Example
 ///
 /// ```rust
-/// use atlas_core::hash::{calculate_hash, combine_hashes};
+/// use atlas_common::hash::{calculate_hash, combine_hashes};
 ///
 /// let hash1 = calculate_hash(b"data1");
 /// let hash2 = calculate_hash(b"data2");
 /// let combined = combine_hashes(&[&hash1, &hash2])?;
-/// # Ok::<(), atlas_core::Error>(())
+/// # Ok::<(), atlas_common::Error>(())
 /// ```
 pub fn combine_hashes(hashes: &[&str]) -> Result<String> {
     combine_hashes_with_algorithm(hashes, &HashAlgorithm::Sha384)
@@ -133,7 +133,7 @@ pub fn combine_hashes_with_algorithm(hashes: &[&str], algorithm: &HashAlgorithm)
 /// # Example
 ///
 /// ```rust
-/// use atlas_core::hash::{calculate_hash, verify_hash};
+/// use atlas_common::hash::{calculate_hash, verify_hash};
 ///
 /// let data = b"test data";
 /// let hash = calculate_hash(data);
@@ -190,7 +190,7 @@ pub fn verify_file_hash_with_algorithm(
 /// # Example
 ///
 /// ```rust
-/// use atlas_core::hash::{detect_hash_algorithm, HashAlgorithm};
+/// use atlas_common::hash::{detect_hash_algorithm, HashAlgorithm};
 ///
 /// let sha256_hash = "a".repeat(64);
 /// assert_eq!(detect_hash_algorithm(&sha256_hash), HashAlgorithm::Sha256);
@@ -209,7 +209,7 @@ pub fn detect_hash_algorithm(hash: &str) -> HashAlgorithm {
 /// # Example
 ///
 /// ```rust
-/// use atlas_core::hash::{get_hash_length, HashAlgorithm};
+/// use atlas_common::hash::{get_hash_length, HashAlgorithm};
 ///
 /// assert_eq!(get_hash_length(&HashAlgorithm::Sha256), 64);
 /// assert_eq!(get_hash_length(&HashAlgorithm::Sha384), 96);
@@ -236,7 +236,7 @@ pub fn get_hash_length(algorithm: &HashAlgorithm) -> usize {
 /// # Example
 ///
 /// ```rust
-/// use atlas_core::hash::validate_hash_format;
+/// use atlas_common::hash::validate_hash_format;
 ///
 /// assert!(validate_hash_format(&"a".repeat(96)).is_ok());
 /// assert!(validate_hash_format("not-a-hash").is_err());

--- a/src/hash/mod.rs
+++ b/src/hash/mod.rs
@@ -1,7 +1,31 @@
-//! # Hash Module
+//! Cryptographic hash functionality
 //!
-//! Provides cryptographic hash functions supporting SHA-256, SHA-384, and SHA-512.
-
+//! This module provides secure cryptographic hashing with support for SHA-256, SHA-384, and SHA-512.
+//! It includes utilities for file hashing, hash verification, and incremental hashing.
+//!
+//! # Features
+//!
+//! - Multiple hash algorithms (SHA-256, SHA-384, SHA-512)
+//! - File and data hashing
+//! - Constant-time hash comparison for security
+//! - Incremental hashing with `HashBuilder`
+//! - Hash combination for merkle-tree-like structures
+//!
+//! # Example
+//!
+//! ```rust
+//! use atlas_core::hash::{calculate_hash, verify_hash, HashAlgorithm};
+//!
+//! let data = b"important data";
+//! let hash = calculate_hash(data);
+//! assert!(verify_hash(data, &hash));
+//!
+//! // Use specific algorithm
+//! let sha256_hash = atlas_core::hash::calculate_hash_with_algorithm(
+//!     data,
+//!     &HashAlgorithm::Sha256
+//! );
+//! ```
 mod algorithms;
 
 pub use algorithms::{HashAlgorithm, HashBuilder, Hasher};
@@ -26,12 +50,32 @@ pub fn calculate_hash_with_algorithm(data: &[u8], algorithm: &HashAlgorithm) -> 
     }
 }
 
-/// Calculate file hash using the default algorithm (SHA-384)
+/// Calculate hash using the default algorithm (SHA-384)
+///
+/// # Example
+///
+/// ```rust
+/// use atlas_core::hash::calculate_hash;
+///
+/// let data = b"test data";
+/// let hash = calculate_hash(data);
+/// assert_eq!(hash.len(), 96); // SHA-384 produces 96 hex characters
+/// ```
 pub fn calculate_file_hash(path: impl AsRef<Path>) -> Result<String> {
     calculate_file_hash_with_algorithm(path, &HashAlgorithm::Sha384)
 }
 
-/// Calculate file hash with specific algorithm
+/// Calculate hash with a specific algorithm
+///
+/// # Example
+///
+/// ```rust
+/// use atlas_core::hash::{calculate_hash_with_algorithm, HashAlgorithm};
+///
+/// let data = b"test data";
+/// let sha256_hash = calculate_hash_with_algorithm(data, &HashAlgorithm::Sha256);
+/// assert_eq!(sha256_hash.len(), 64);
+/// ```
 pub fn calculate_file_hash_with_algorithm(
     path: impl AsRef<Path>,
     algorithm: &HashAlgorithm,
@@ -46,11 +90,32 @@ pub fn calculate_file_hash_with_algorithm(
 }
 
 /// Combine multiple hashes into a single hash
+///
+/// Useful for creating merkle-tree-like structures or combining multiple asset hashes.
+///
+/// # Errors
+///
+/// Returns an error if any hash string is invalid hex.
+///
+/// # Example
+///
+/// ```rust
+/// use atlas_core::hash::{calculate_hash, combine_hashes};
+///
+/// let hash1 = calculate_hash(b"data1");
+/// let hash2 = calculate_hash(b"data2");
+/// let combined = combine_hashes(&[&hash1, &hash2])?;
+/// # Ok::<(), atlas_core::Error>(())
+/// ```
 pub fn combine_hashes(hashes: &[&str]) -> Result<String> {
     combine_hashes_with_algorithm(hashes, &HashAlgorithm::Sha384)
 }
 
-/// Combine hashes with specific algorithm
+/// Combine hashes with a specific algorithm
+///
+/// # Errors
+///
+/// Returns an error if any hash string is invalid hex.
 pub fn combine_hashes_with_algorithm(hashes: &[&str], algorithm: &HashAlgorithm) -> Result<String> {
     let mut combined = Vec::new();
     for hash in hashes {
@@ -60,13 +125,28 @@ pub fn combine_hashes_with_algorithm(hashes: &[&str], algorithm: &HashAlgorithm)
     Ok(calculate_hash_with_algorithm(&combined, algorithm))
 }
 
-/// Verify data against expected hash
+/// Verify data against an expected hash
+///
+/// Automatically detects the hash algorithm from the hash length.
+/// Uses constant-time comparison to prevent timing attacks.
+///
+/// # Example
+///
+/// ```rust
+/// use atlas_core::hash::{calculate_hash, verify_hash};
+///
+/// let data = b"test data";
+/// let hash = calculate_hash(data);
+/// assert!(verify_hash(data, &hash));
+/// ```
 pub fn verify_hash(data: &[u8], expected_hash: &str) -> bool {
     let algorithm = detect_hash_algorithm(expected_hash);
     verify_hash_with_algorithm(data, expected_hash, &algorithm)
 }
 
-/// Verify hash with specific algorithm
+/// Verify hash with a specific algorithm
+///
+/// Uses constant-time comparison to prevent timing attacks.
 pub fn verify_hash_with_algorithm(
     data: &[u8],
     expected_hash: &str,
@@ -77,12 +157,20 @@ pub fn verify_hash_with_algorithm(
 }
 
 /// Verify file hash
+///
+/// # Errors
+///
+/// Returns an error if the file cannot be read.
 pub fn verify_file_hash(path: impl AsRef<Path>, expected_hash: &str) -> Result<bool> {
     let algorithm = detect_hash_algorithm(expected_hash);
     verify_file_hash_with_algorithm(path, expected_hash, &algorithm)
 }
 
-/// Verify file hash with specific algorithm
+/// Verify file hash with a specific algorithm
+///
+/// # Errors
+///
+/// Returns an error if the file cannot be read.
 pub fn verify_file_hash_with_algorithm(
     path: impl AsRef<Path>,
     expected_hash: &str,
@@ -93,6 +181,20 @@ pub fn verify_file_hash_with_algorithm(
 }
 
 /// Detect hash algorithm from hash length
+///
+/// Returns:
+/// - SHA-256 for 64 character hashes
+/// - SHA-384 for 96 character hashes (default)
+/// - SHA-512 for 128 character hashes
+///
+/// # Example
+///
+/// ```rust
+/// use atlas_core::hash::{detect_hash_algorithm, HashAlgorithm};
+///
+/// let sha256_hash = "a".repeat(64);
+/// assert_eq!(detect_hash_algorithm(&sha256_hash), HashAlgorithm::Sha256);
+/// ```
 pub fn detect_hash_algorithm(hash: &str) -> HashAlgorithm {
     match hash.len() {
         64 => HashAlgorithm::Sha256,
@@ -102,7 +204,17 @@ pub fn detect_hash_algorithm(hash: &str) -> HashAlgorithm {
     }
 }
 
-/// Get expected hash length for algorithm
+/// Get expected hash length in hex characters for an algorithm
+///
+/// # Example
+///
+/// ```rust
+/// use atlas_core::hash::{get_hash_length, HashAlgorithm};
+///
+/// assert_eq!(get_hash_length(&HashAlgorithm::Sha256), 64);
+/// assert_eq!(get_hash_length(&HashAlgorithm::Sha384), 96);
+/// assert_eq!(get_hash_length(&HashAlgorithm::Sha512), 128);
+/// ```
 pub fn get_hash_length(algorithm: &HashAlgorithm) -> usize {
     match algorithm {
         HashAlgorithm::Sha256 => 64,
@@ -112,6 +224,23 @@ pub fn get_hash_length(algorithm: &HashAlgorithm) -> usize {
 }
 
 /// Validate hash format
+///
+/// Checks that a hash string:
+/// - Contains only hexadecimal characters
+/// - Has a valid length (64, 96, or 128 characters)
+///
+/// # Errors
+///
+/// Returns an error if the hash format is invalid.
+///
+/// # Example
+///
+/// ```rust
+/// use atlas_core::hash::validate_hash_format;
+///
+/// assert!(validate_hash_format(&"a".repeat(96)).is_ok());
+/// assert!(validate_hash_format("not-a-hash").is_err());
+/// ```
 pub fn validate_hash_format(hash: &str) -> Result<()> {
     if !hash.chars().all(|c| c.is_ascii_hexdigit()) {
         return Err(Error::Validation(

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,17 +1,60 @@
 //! # Atlas Core
 //!
-//! Core functionality shared across Atlas components including hashing,
-//! C2PA metadata types, storage abstractions, and utilities.
+//! Core functionality shared across Atlas components for machine learning provenance tracking.
+//!
+//! This crate provides essential building blocks for creating Content Authenticity Initiative (C2PA)
+//! compliant systems for tracking the provenance of machine learning models, datasets, and related assets.
 //!
 //! ## Features
 //!
-//! - `hash` (default): Cryptographic hash functions (SHA-256/384/512)
+//! - **Cryptographic Hashing**: SHA-256/384/512 support with constant-time comparison
+//! - **C2PA Metadata**: Types and utilities for C2PA manifest management
+//! - **Storage Abstractions**: Backend-agnostic storage interfaces
+//! - **Validation**: Comprehensive validation for manifests, URNs, and hashes
+//! - **Secure File Operations**: Protection against symlink and hardlink attacks
+//!
+//! ## Feature Flags
+//!
+//! - `hash` (default): Cryptographic hash functions
 //! - `c2pa` (default): C2PA manifest and asset types
 //! - `storage`: Storage backend abstractions
-//! - `validation`: Validation utilities for manifests and hashes
+//! - `validation`: Validation utilities
 //! - `file-utils`: Secure file operation utilities
 //! - `async`: Async support for storage operations
 //! - `full`: Enable all features
+//!
+//! ## Example
+//!
+//! ```rust
+//! use atlas_core::{
+//!     hash::{calculate_hash, HashAlgorithm},
+//!     c2pa::{ManifestId, ManifestMetadata, ManifestType},
+//!     Result,
+//! };
+//!
+//! fn main() -> Result<()> {
+//!     // Calculate hash of model data
+//!     let model_data = b"pretrained weights";
+//!     let hash = calculate_hash(model_data);
+//!     
+//!     // Create a C2PA manifest ID
+//!     let manifest_id = ManifestId::new();
+//!     println!("Manifest URN: {}", manifest_id.as_urn());
+//!     
+//!     // Create manifest metadata
+//!     let metadata = ManifestMetadata {
+//!         id: manifest_id.as_urn().to_string(),
+//!         name: "GPT-2 Fine-tuned Model".to_string(),
+//!         manifest_type: ManifestType::Model,
+//!         created_at: atlas_core::c2pa::DateTimeWrapper::now_utc().to_rfc3339(),
+//!         hash: Some(hash),
+//!         size: Some(1024 * 1024 * 50),
+//!         version: Some("1.0.0".to_string()),
+//!     };
+//!     
+//!     Ok(())
+//! }
+//! ```
 
 #![doc(html_root_url = "https://docs.rs/atlas-core/0.1.0")]
 
@@ -48,8 +91,21 @@ pub use storage::{StorageBackend, StorageConfig, StorageType};
 
 /// Library version
 pub const VERSION: &str = env!("CARGO_PKG_VERSION");
-
-/// Initialize the library (for future use)
+/// Initialize the library
+///
+/// Currently a no-op but reserved for future initialization requirements.
+///
+/// # Example
+///
+/// ```rust
+/// use atlas_core::init;
+///
+/// fn main() -> atlas_core::Result<()> {
+///     init()?;
+///     // Your code here
+///     Ok(())
+/// }
+/// ```
 pub fn init() -> Result<()> {
     Ok(())
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,4 +1,4 @@
-//! # Atlas Core
+//! # Atlas Common
 //!
 //! Core functionality shared across Atlas components for machine learning provenance tracking.
 //!
@@ -26,7 +26,7 @@
 //! ## Example
 //!
 //! ```rust
-//! use atlas_core::{
+//! use atlas_common::{
 //!     hash::{calculate_hash, HashAlgorithm},
 //!     c2pa::{ManifestId, ManifestMetadata, ManifestType},
 //!     Result,
@@ -46,7 +46,7 @@
 //!         id: manifest_id.as_urn().to_string(),
 //!         name: "GPT-2 Fine-tuned Model".to_string(),
 //!         manifest_type: ManifestType::Model,
-//!         created_at: atlas_core::c2pa::DateTimeWrapper::now_utc().to_rfc3339(),
+//!         created_at: atlas_common::c2pa::DateTimeWrapper::now_utc().to_rfc3339(),
 //!         hash: Some(hash),
 //!         size: Some(1024 * 1024 * 50),
 //!         version: Some("1.0.0".to_string()),
@@ -56,7 +56,7 @@
 //! }
 //! ```
 
-#![doc(html_root_url = "https://docs.rs/atlas-core/0.1.0")]
+#![doc(html_root_url = "https://docs.rs/atlas-common/0.1.0")]
 
 // Common error types are always available
 pub mod error;
@@ -98,9 +98,9 @@ pub const VERSION: &str = env!("CARGO_PKG_VERSION");
 /// # Example
 ///
 /// ```rust
-/// use atlas_core::init;
+/// use atlas_common::init;
 ///
-/// fn main() -> atlas_core::Result<()> {
+/// fn main() -> atlas_common::Result<()> {
 ///     init()?;
 ///     // Your code here
 ///     Ok(())

--- a/src/storage/backend.rs
+++ b/src/storage/backend.rs
@@ -1,10 +1,28 @@
+//! Storage backend trait definition
+
 use crate::error::Result;
 use std::any::Any;
 
-/// Storage backend trait
+/// Storage backend trait for different storage implementations
+///
+/// This trait provides a common interface for storage operations
+/// across different backend types (filesystem, S3, database, etc.).
+///
+/// # Async Support
+///
+/// When the `async` feature is enabled, all methods become async.
 #[cfg_attr(feature = "async", async_trait::async_trait)]
 pub trait StorageBackend: Send + Sync {
     /// Store data with an ID
+    ///
+    /// # Arguments
+    ///
+    /// * `id` - Unique identifier for the data
+    /// * `data` - Raw bytes to store
+    ///
+    /// # Errors
+    ///
+    /// Returns an error if storage fails.
     #[cfg(not(feature = "async"))]
     fn store(&self, id: &str, data: &[u8]) -> Result<()>;
 
@@ -12,13 +30,25 @@ pub trait StorageBackend: Send + Sync {
     async fn store(&self, id: &str, data: &[u8]) -> Result<()>;
 
     /// Retrieve data by ID
+    ///
+    /// # Arguments
+    ///
+    /// * `id` - Unique identifier of the data to retrieve
+    ///
+    /// # Errors
+    ///
+    /// Returns an error if the ID is not found or retrieval fails.
     #[cfg(not(feature = "async"))]
     fn retrieve(&self, id: &str) -> Result<Vec<u8>>;
 
     #[cfg(feature = "async")]
     async fn retrieve(&self, id: &str) -> Result<Vec<u8>>;
 
-    /// List all IDs
+    /// List all stored IDs
+    ///
+    /// # Errors
+    ///
+    /// Returns an error if listing fails.
     #[cfg(not(feature = "async"))]
     fn list(&self) -> Result<Vec<String>>;
 
@@ -26,6 +56,14 @@ pub trait StorageBackend: Send + Sync {
     async fn list(&self) -> Result<Vec<String>>;
 
     /// Delete data by ID
+    ///
+    /// # Arguments
+    ///
+    /// * `id` - Unique identifier of the data to delete
+    ///
+    /// # Errors
+    ///
+    /// Returns an error if deletion fails.
     #[cfg(not(feature = "async"))]
     fn delete(&self, id: &str) -> Result<()>;
 
@@ -33,6 +71,14 @@ pub trait StorageBackend: Send + Sync {
     async fn delete(&self, id: &str) -> Result<()>;
 
     /// Check if ID exists
+    ///
+    /// # Arguments
+    ///
+    /// * `id` - Unique identifier to check
+    ///
+    /// # Errors
+    ///
+    /// Returns an error if the check fails.
     #[cfg(not(feature = "async"))]
     fn exists(&self, id: &str) -> Result<bool>;
 
@@ -40,5 +86,7 @@ pub trait StorageBackend: Send + Sync {
     async fn exists(&self, id: &str) -> Result<bool>;
 
     /// Get as Any for downcasting
+    ///
+    /// Allows runtime type checking and casting to concrete types.
     fn as_any(&self) -> &dyn Any;
 }

--- a/src/storage/config.rs
+++ b/src/storage/config.rs
@@ -1,26 +1,49 @@
+//! Storage configuration types
+
 use super::types::StorageType;
 use serde::{Deserialize, Serialize};
 
-/// Storage configuration
+/// Storage backend configuration
+///
+/// Contains all necessary information to initialize a storage backend.
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct StorageConfig {
+    /// Type of storage backend
     pub storage_type: StorageType,
+
+    /// Connection URL (for databases, S3, etc.)
     pub url: Option<String>,
+
+    /// File system path (for filesystem storage)
     pub path: Option<String>,
+
+    /// Authentication credentials
     pub credentials: Option<StorageCredentials>,
+
+    /// Additional backend-specific options as JSON
     pub options: Option<serde_json::Value>,
 }
 
-/// Storage credentials
+/// Storage authentication credentials
+///
+/// Supports various authentication methods for different backends.
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct StorageCredentials {
+    /// Username for basic auth
     pub username: Option<String>,
+
+    /// Password for basic auth
     pub password: Option<String>,
+
+    /// Bearer token
     pub token: Option<String>,
+
+    /// API key
     pub api_key: Option<String>,
 }
 
 impl Default for StorageConfig {
+    /// Creates default filesystem storage configuration
     fn default() -> Self {
         Self {
             storage_type: StorageType::Filesystem,

--- a/src/storage/mod.rs
+++ b/src/storage/mod.rs
@@ -3,6 +3,18 @@
 //! This module provides traits and types for abstracting storage backends,
 //! allowing the Atlas system to work with different storage systems
 //! (filesystem, database, cloud storage, etc.).
+//!
+//! # Example
+//!
+//! ```rust
+//! use atlas_core::storage::{StorageConfig, StorageType};
+//!
+//! let config = StorageConfig {
+//!     storage_type: StorageType::S3,
+//!     url: Some("s3://my-bucket/manifests".to_string()),
+//!     ..Default::default()
+//! };
+//! ```
 
 mod backend;
 mod config;

--- a/src/storage/mod.rs
+++ b/src/storage/mod.rs
@@ -7,7 +7,7 @@
 //! # Example
 //!
 //! ```rust
-//! use atlas_core::storage::{StorageConfig, StorageType};
+//! use atlas_common::storage::{StorageConfig, StorageType};
 //!
 //! let config = StorageConfig {
 //!     storage_type: StorageType::S3,

--- a/src/storage/types.rs
+++ b/src/storage/types.rs
@@ -1,16 +1,27 @@
+//! Storage type definitions
+
 use serde::{Deserialize, Serialize};
 
-/// Storage types
+/// Available storage backend types
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
 pub enum StorageType {
+    /// Local filesystem storage
     #[serde(rename = "filesystem")]
     Filesystem,
+
+    /// Database storage (PostgreSQL, MySQL, etc.)
     #[serde(rename = "database")]
     Database,
+
+    /// Rekor transparency log
     #[serde(rename = "rekor")]
     Rekor,
+
+    /// Amazon S3 or compatible object storage
     #[serde(rename = "s3")]
     S3,
+
+    /// In-memory storage (for testing)
     #[serde(rename = "memory")]
     Memory,
 }

--- a/src/validation/c2pa.rs
+++ b/src/validation/c2pa.rs
@@ -13,7 +13,7 @@ use uuid::Uuid;
 /// # Example
 ///
 /// ```rust
-/// use atlas_core::validation::ensure_c2pa_urn;
+/// use atlas_common::validation::ensure_c2pa_urn;
 ///
 /// let urn1 = ensure_c2pa_urn("urn:c2pa:123e4567-e89b-12d3-a456-426614174000");
 /// let urn2 = ensure_c2pa_urn("123e4567-e89b-12d3-a456-426614174000");
@@ -38,12 +38,12 @@ pub fn ensure_c2pa_urn(id: &str) -> String {
 /// # Example
 ///
 /// ```rust
-/// use atlas_core::validation::extract_uuid_from_urn;
+/// use atlas_common::validation::extract_uuid_from_urn;
 ///
 /// let uuid = extract_uuid_from_urn(
 ///     "urn:c2pa:123e4567-e89b-12d3-a456-426614174000"
 /// )?;
-/// # Ok::<(), atlas_core::Error>(())
+/// # Ok::<(), atlas_common::Error>(())
 /// ```
 pub fn extract_uuid_from_urn(urn: &str) -> Result<Uuid> {
     let parts: Vec<&str> = urn.split(':').collect();

--- a/src/validation/c2pa.rs
+++ b/src/validation/c2pa.rs
@@ -1,7 +1,24 @@
+//! C2PA URN validation utilities
+
 use crate::error::{Error, Result};
 use uuid::Uuid;
 
 /// Ensure ID is in C2PA URN format
+///
+/// Converts various ID formats to proper C2PA URN format:
+/// - Already valid URN: returned as-is
+/// - Valid UUID: wrapped in URN format
+/// - Other strings: generates new UUID and creates URN
+///
+/// # Example
+///
+/// ```rust
+/// use atlas_core::validation::ensure_c2pa_urn;
+///
+/// let urn1 = ensure_c2pa_urn("urn:c2pa:123e4567-e89b-12d3-a456-426614174000");
+/// let urn2 = ensure_c2pa_urn("123e4567-e89b-12d3-a456-426614174000");
+/// let urn3 = ensure_c2pa_urn("custom-id");
+/// ```
 pub fn ensure_c2pa_urn(id: &str) -> String {
     if id.starts_with("urn:c2pa:") {
         id.to_string()
@@ -13,6 +30,21 @@ pub fn ensure_c2pa_urn(id: &str) -> String {
 }
 
 /// Extract UUID from C2PA URN
+///
+/// # Errors
+///
+/// Returns an error if the URN format is invalid or doesn't contain a valid UUID.
+///
+/// # Example
+///
+/// ```rust
+/// use atlas_core::validation::extract_uuid_from_urn;
+///
+/// let uuid = extract_uuid_from_urn(
+///     "urn:c2pa:123e4567-e89b-12d3-a456-426614174000"
+/// )?;
+/// # Ok::<(), atlas_core::Error>(())
+/// ```
 pub fn extract_uuid_from_urn(urn: &str) -> Result<Uuid> {
     let parts: Vec<&str> = urn.split(':').collect();
 
@@ -28,6 +60,13 @@ pub fn extract_uuid_from_urn(urn: &str) -> Result<Uuid> {
 }
 
 /// Validate C2PA URN format
+///
+/// Checks that a URN follows the C2PA format:
+/// `urn:c2pa:UUID[:claim_generator[:version_reason]]`
+///
+/// # Errors
+///
+/// Returns an error if the URN format is invalid.
 pub fn validate_c2pa_urn(urn: &str) -> Result<()> {
     let parts: Vec<&str> = urn.split(':').collect();
 

--- a/src/validation/hash.rs
+++ b/src/validation/hash.rs
@@ -1,6 +1,14 @@
+//! Hash validation utilities
+
 use crate::error::Result;
 
 /// Validate manifest hash format
+///
+/// Delegates to the hash module's validation function.
+///
+/// # Errors
+///
+/// Returns an error if the hash format is invalid.
 pub fn validate_manifest_hash(hash: &str) -> Result<()> {
     crate::hash::validate_hash_format(hash)
 }

--- a/src/validation/manifest.rs
+++ b/src/validation/manifest.rs
@@ -1,7 +1,18 @@
+//! Manifest validation utilities
+
 use crate::error::{Error, Result};
 use uuid::Uuid;
 
 /// Validate manifest ID format
+///
+/// Accepts:
+/// - C2PA URN format: `urn:c2pa:UUID[:claim_generator[:version_reason]]`
+/// - Plain UUID: `123e4567-e89b-12d3-a456-426614174000`
+/// - Alphanumeric IDs with hyphens and underscores
+///
+/// # Errors
+///
+/// Returns an error if the ID format is invalid.
 pub fn validate_manifest_id(id: &str) -> Result<()> {
     if id.is_empty() {
         return Err(Error::Validation("Manifest ID cannot be empty".to_string()));
@@ -24,7 +35,7 @@ pub fn validate_manifest_id(id: &str) -> Result<()> {
     Ok(())
 }
 
-/// Validate C2PA URN format
+/// Validate C2PA URN format (internal helper)
 fn validate_c2pa_urn_format(urn: &str) -> Result<()> {
     let parts: Vec<&str> = urn.split(':').collect();
 
@@ -60,6 +71,35 @@ fn validate_c2pa_urn_format(urn: &str) -> Result<()> {
 }
 
 /// Validate manifest metadata
+///
+/// Checks that:
+/// - ID is valid
+/// - Name is not empty
+/// - Hash format is valid (if present)
+///
+/// # Errors
+///
+/// Returns an error if validation fails.
+///
+/// # Example
+///
+/// ```rust
+/// use atlas_core::c2pa::{ManifestMetadata, ManifestType, DateTimeWrapper};
+/// use atlas_core::validation::validate_manifest_metadata;
+///
+/// let metadata = ManifestMetadata {
+///     id: "urn:c2pa:123e4567-e89b-12d3-a456-426614174000".to_string(),
+///     name: "My Model".to_string(),
+///     manifest_type: ManifestType::Model,
+///     created_at: DateTimeWrapper::now_utc().to_rfc3339(),
+///     hash: Some("a".repeat(96)),
+///     size: Some(1024),
+///     version: Some("1.0.0".to_string()),
+/// };
+///
+/// validate_manifest_metadata(&metadata)?;
+/// # Ok::<(), atlas_core::Error>(())
+/// ```
 pub fn validate_manifest_metadata(metadata: &crate::c2pa::ManifestMetadata) -> Result<()> {
     validate_manifest_id(&metadata.id)?;
 

--- a/src/validation/manifest.rs
+++ b/src/validation/manifest.rs
@@ -84,8 +84,8 @@ fn validate_c2pa_urn_format(urn: &str) -> Result<()> {
 /// # Example
 ///
 /// ```rust
-/// use atlas_core::c2pa::{ManifestMetadata, ManifestType, DateTimeWrapper};
-/// use atlas_core::validation::validate_manifest_metadata;
+/// use atlas_common::c2pa::{ManifestMetadata, ManifestType, DateTimeWrapper};
+/// use atlas_common::validation::validate_manifest_metadata;
 ///
 /// let metadata = ManifestMetadata {
 ///     id: "urn:c2pa:123e4567-e89b-12d3-a456-426614174000".to_string(),
@@ -98,7 +98,7 @@ fn validate_c2pa_urn_format(urn: &str) -> Result<()> {
 /// };
 ///
 /// validate_manifest_metadata(&metadata)?;
-/// # Ok::<(), atlas_core::Error>(())
+/// # Ok::<(), atlas_common::Error>(())
 /// ```
 pub fn validate_manifest_metadata(metadata: &crate::c2pa::ManifestMetadata) -> Result<()> {
     validate_manifest_id(&metadata.id)?;

--- a/src/validation/mod.rs
+++ b/src/validation/mod.rs
@@ -6,7 +6,7 @@
 //! # Example
 //!
 //! ```rust
-//! use atlas_core::validation::{validate_manifest_id, ensure_c2pa_urn};
+//! use atlas_common::validation::{validate_manifest_id, ensure_c2pa_urn};
 //!
 //! // Validate a manifest ID
 //! validate_manifest_id("urn:c2pa:123e4567-e89b-12d3-a456-426614174000")?;
@@ -14,7 +14,7 @@
 //! // Ensure proper URN format
 //! let urn = ensure_c2pa_urn("my-custom-id");
 //! assert!(urn.starts_with("urn:c2pa:"));
-//! # Ok::<(), atlas_core::Error>(())
+//! # Ok::<(), atlas_common::Error>(())
 //! ```
 
 mod c2pa;

--- a/src/validation/mod.rs
+++ b/src/validation/mod.rs
@@ -1,7 +1,21 @@
 //! Validation utilities for manifests and hashes
 //!
-//! This module provides validation functions for C2PA manifests,
+//! This module provides comprehensive validation functions for C2PA manifests,
 //! URNs, hashes, and other data structures used in the Atlas system.
+//!
+//! # Example
+//!
+//! ```rust
+//! use atlas_core::validation::{validate_manifest_id, ensure_c2pa_urn};
+//!
+//! // Validate a manifest ID
+//! validate_manifest_id("urn:c2pa:123e4567-e89b-12d3-a456-426614174000")?;
+//!
+//! // Ensure proper URN format
+//! let urn = ensure_c2pa_urn("my-custom-id");
+//! assert!(urn.starts_with("urn:c2pa:"));
+//! # Ok::<(), atlas_core::Error>(())
+//! ```
 
 mod c2pa;
 mod hash;

--- a/tests/c2pa_tests.rs
+++ b/tests/c2pa_tests.rs
@@ -2,8 +2,8 @@
 
 #![cfg(feature = "c2pa")]
 
-use atlas_core::c2pa::*;
-use atlas_core::Result;
+use atlas_common::c2pa::*;
+use atlas_common::Result;
 use std::path::Path;
 
 #[test]

--- a/tests/hash_tests.rs
+++ b/tests/hash_tests.rs
@@ -2,8 +2,8 @@
 
 #![cfg(feature = "hash")]
 
-use atlas_core::hash::*;
-use atlas_core::Result;
+use atlas_common::hash::*;
+use atlas_common::Result;
 use std::fs;
 use tempfile::tempdir;
 
@@ -79,7 +79,7 @@ fn test_hash_builder() {
 
 #[test]
 fn test_hasher_trait() {
-    use atlas_core::hash::Hasher;
+    use atlas_common::hash::Hasher;
 
     let data = "test string";
     let hash1 = data.hash(HashAlgorithm::Sha256);

--- a/tests/validation_tests.rs
+++ b/tests/validation_tests.rs
@@ -2,9 +2,9 @@
 
 #![cfg(feature = "validation")]
 
-use atlas_core::c2pa::{DateTimeWrapper, ManifestMetadata, ManifestType};
-use atlas_core::validation::*;
-use atlas_core::Result;
+use atlas_common::c2pa::{DateTimeWrapper, ManifestMetadata, ManifestType};
+use atlas_common::validation::*;
+use atlas_common::Result;
 use uuid::Uuid;
 
 #[test]


### PR DESCRIPTION
- Added docstrings to public APIs in atlas-core to prepare for crates.io publishing. Included examples tested via cargo test --doc. 
- Fixed full_example.rs to handle feature gates and corrected Path usage in file module examples. 
- Added README.md with quick start guide and Cargo.toml metadata for crates.io.
- Tests pass with cargo test --all-features and docs render correctly with cargo doc --all-features —open.
- Ready for publishing.