### PR TITLE
Fix syntax error in AssetType enum and update tests

### DIFF
--- a/src/c2pa/asset.rs
+++ b/src/c2pa/asset.rs
@@ -62,7 +62,7 @@ pub enum AssetType {
     // SerializationFormats
     /// NumPy array format
     #[serde(rename = "c2pa.types.numpy")]
-    SerializationNumpy
+    SerializationNumpy,
 
     /// Python pickle format
     #[serde(rename = "c2pa.types.format.pickle")]
@@ -130,7 +130,7 @@ pub fn determine_model_type(path: &Path) -> Result<AssetType> {
         Some("onnx") => Ok(AssetType::ModelOnnx),
         Some("bin") | Some("xml") => Ok(AssetType::ModelOpenVino),
         Some("h5") | Some("keras") | Some("hdf5") => Ok(AssetType::Model),
-        Some("npy") | Some("npz") => Ok(AssetType::FormatNumpy),
+        Some("npy") | Some("npz") => Ok(AssetType::SerializationNumpy),
         Some("pkl") | Some("pickle") => Ok(AssetType::FormatPickle),
         Some("protobuf") | Some("proto") => Ok(AssetType::FormatProtobuf),
         Some(_) => Ok(AssetType::Model),

--- a/tests/c2pa_tests.rs
+++ b/tests/c2pa_tests.rs
@@ -118,7 +118,7 @@ fn test_model_type_detection() -> Result<()> {
         ("model.bin", AssetType::ModelOpenVino),
         ("model.h5", AssetType::Model),
         ("model.keras", AssetType::Model),
-        ("model.npy", AssetType::FormatNumpy),
+        ("model.npy", AssetType::SerializationNumpy),
         ("model.pkl", AssetType::FormatPickle),
         ("model.unknown", AssetType::Model),
     ];
@@ -224,7 +224,7 @@ fn test_asset_type_serialization() -> Result<()> {
         (AssetType::Dataset, r#""c2pa.types.dataset""#),
         (AssetType::ModelOnnx, r#""c2pa.types.model.onnx""#),
         (AssetType::Software, r#""c2pa.types.software""#),
-        (AssetType::FormatNumpy, r#""c2pa.types.format.numpy""#),
+        (AssetType::SerializationNumpy, r#""c2pa.types.numpy""#),
     ];
 
     for (asset_type, expected_json) in test_cases {


### PR DESCRIPTION
Added missing comma after SerializationNumpy variant in the AssetType enum that was causing a parse error, 
Fixed related tests to reflect the changes
